### PR TITLE
Download translation, and upload source docs in CI.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,17 @@ jobs:
           command: |
             git config --global user.email "devhub-deploy@users.noreply.github.com"
             git config --global user.name "Devhub Deployer"
-            cd website && yarn install && USE_SSH=true GIT_USER=git yarn run publish-gh-pages
+            # install Docusaurus and generate file of English strings
+            - cd website && yarn install && yarn run write-translations && cd ..
+            # crowdin install
+            - sudo apt-get install default-jre
+            - wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
+            - sudo dpkg -i crowdin.deb
+            # translations upload/download
+            - crowdin --config crowdin.yaml upload sources --auto-update -b master
+            - crowdin --config crowdin.yaml download -b master
+            # build and publish website
+            cd website && USE_SSH=true GIT_USER=git yarn run publish-gh-pages
 
 workflows:
   version: 2


### PR DESCRIPTION
Issue [link](https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/issues/84#issuecomment-499744642)

* I have manually published to my own [website](https://whisperd.tech/substrate-developer-hub.github.io/), the images for `Who is Building on Substrate?` is lost, because I add `baseUrl: '/substrate-developer-hub.github.io/'` in my publishment.  It should work under substrate.dev.
* The circleci build needs to hold two environment variables `CROWDIN_DOCUSAURUS_PROJECT_ID`, `CROWDIN_DOCUSAURUS_API_KEY`, need to figure out how to configure the value in circleci.
