### PR TITLE
Emphasize default_features = false

### DIFF
--- a/docs/tutorials/creating-a-runtime-module.md
+++ b/docs/tutorials/creating-a-runtime-module.md
@@ -154,6 +154,7 @@ First we need to add our newly-created crate as a dependency in the node runtime
 default_features = false
 path = "../../test_module"
 ```
+> You **must** set `default_features = false` so that your runtime will successfully compile to wasm.
 
 And just as before, we need to tell the module to only build its `std` feature when the runtime itself does.
 ```toml

--- a/website/versioned_docs/version-1.0.0/tutorials/creating-a-runtime-module.md
+++ b/website/versioned_docs/version-1.0.0/tutorials/creating-a-runtime-module.md
@@ -157,6 +157,8 @@ default_features = false
 path = "../../test_module"
 ```
 
+> You **must** set `default_features = false` so that your runtime will successfully compile to wasm.
+
 And just as before, we need to tell the module to only build its `std` feature when the runtime itself does.
 ```toml
 std = [


### PR DESCRIPTION
As requested by @bkchr, This PR emphasizes `default_features = false` to help readers familiar with rust, but not substrate avoid reading over the advice by accident.