### PR TITLE
Fix typo and clarify default value usage

### DIFF
--- a/docs/runtime/initializing-storage.md
+++ b/docs/runtime/initializing-storage.md
@@ -8,7 +8,7 @@ In some cases storage should be initialized with a value before any user has int
 
 ## Hard-Code Default Values
 
-The simplest way (and one that technically does not use genesis configuration) to initialize storage is simply to hard-code default values for each parameter. This option is best when there are clear default values that all deployments of the module will want to use. The runtime developer can choose this option by including `config()` in the `decl_storage!` marco, and an initial value at the end of the line.
+The simplest way (and one that technically does not use genesis configuration) to initialize storage is simply to hard-code default values for each parameter. This option is best when there are clear default values that all deployments of the module will want to use. The runtime developer can choose this option by including `config()` in the `decl_storage!` macro, and an initial value at the end of the line.
 
 Consider this example module where players ante to play a game and add to the pot by raising.
 
@@ -28,7 +28,7 @@ decl_storage! {
 
 ## Defer until Deploy Time with `config()`
 
-The second option available to runtime developers is to actually _not_ specify their own genesis values, but to leave that option up to whomever actually deploys the module in a blockchain. This option makes sense when different deployments of the module, may reasonably want different configuration values, and the various storage values do not need to maintain a particular relationship to one another. The runtime developer can choose this option by including `config()` in the `decl_storage!` marco, and nothing more.
+The second option available to runtime developers is to actually _not_ specify their own genesis values, but to leave that option up to whomever actually deploys the module in a blockchain. This option makes sense when different deployments of the module, may reasonably want different configuration values, and the various storage values do not need to maintain a particular relationship to one another. The runtime developer can choose this option by including `config()` in the `decl_storage!` macro, and nothing more.
 
 ```rust
 decl_storage! {

--- a/docs/runtime/initializing-storage.md
+++ b/docs/runtime/initializing-storage.md
@@ -24,7 +24,7 @@ decl_storage! {
 }
 ```
 
-> Specifying default values this way has the effect that if you ever [`kill`](https://substrate.dev/rustdocs/v1.0/srml_support/storage/trait.StorageValue.html#tymethod.kill) your storage value, it will revert to the default.
+> Specifying default values this way has the effect that if you ever [`kill`](https://substrate.dev/rustdocs/v1.0/srml_support/storage/trait.StorageValue.html#tymethod.kill) your storage value, it will revert to the specified default value.
 
 ## Defer until Deploy Time with `config()`
 

--- a/docs/runtime/macros/decl_module.md
+++ b/docs/runtime/macros/decl_module.md
@@ -68,7 +68,7 @@ You will have to be conscious of any changes you make to the state of your block
 
 Dispatchable functions in your module cannot return a value. Instead it can only return a `Result` which accepts either `Ok(())` when everything has completed successfully or `Err(&'static str)` if something goes wrong.
 
-If you not specify `Result` explicitly as return value, it will be added automatically for you by the `decl_module!` macro and `Ok(())` will be returned at the end.
+If you do not specify `Result` explicitly as return value, it will be added automatically for you by the `decl_module!` macro and `Ok(())` will be returned at the end.
 
 Thus, this function definition is equivalent to the above example:
 

--- a/website/versioned_docs/version-1.0.0/runtime/initializing-storage.md
+++ b/website/versioned_docs/version-1.0.0/runtime/initializing-storage.md
@@ -10,7 +10,7 @@ In some cases storage should be initialized with a value before any user has int
 
 ## Hard-Code Default Values
 
-The simplest way (and one that technically does not use genesis configuration) to initialize storage is simply to hard-code default values for each parameter. This option is best when there are clear default values that all deployments of the module will want to use. The runtime developer can choose this option by including `config()` in the `decl_storage!` marco, and an initial value at the end of the line.
+The simplest way (and one that technically does not use genesis configuration) to initialize storage is simply to hard-code default values for each parameter. This option is best when there are clear default values that all deployments of the module will want to use. The runtime developer can choose this option by including in the `decl_storage!` macro an initial value at the end of the line.
 
 Consider this example module where players ante to play a game and add to the pot by raising.
 
@@ -18,10 +18,10 @@ Consider this example module where players ante to play a game and add to the po
 decl_storage! {
   trait Store for Module<T: Trait> as MyModule {
     // Points ante'd to play the game
-    pub Ante get(ante) config(): u32 = 5;
+    pub Ante get(ante): u32 = 5;
 
     // Minimum raise on each turn
-    pub MinRaise get(min_raise) config(): u32 = 7;
+    pub MinRaise get(min_raise): u32 = 7;
   }
 }
 ```
@@ -30,7 +30,7 @@ decl_storage! {
 
 ## Defer until Deploy Time with `config()`
 
-The second option available to runtime developers is to actually _not_ specify their own genesis values, but to leave that option up to whomever actually deploys the module in a blockchain. This option makes sense when different deployments of the module, may reasonably want different configuration values, and the various storage values do not need to maintain a particular relationship to one another. The runtime developer can choose this option by including `config()` in the `decl_storage!` marco, and nothing more.
+The second option available to runtime developers is to actually _not_ specify their own genesis values, but to leave that option up to whomever actually deploys the module in a blockchain. This option makes sense when different deployments of the module, may reasonably want different configuration values, and the various storage values do not need to maintain a particular relationship to one another. The runtime developer can choose this option by including `config()` in the `decl_storage!` macro, and nothing more.
 
 ```rust
 decl_storage! {

--- a/website/versioned_docs/version-1.0.0/runtime/macros/decl_module.md
+++ b/website/versioned_docs/version-1.0.0/runtime/macros/decl_module.md
@@ -70,7 +70,7 @@ You will have to be conscious of any changes you make to the state of your block
 
 Dispatchable functions in your module cannot return a value. Instead it can only return a `Result` which accepts either `Ok(())` when everything has completed successfully or `Err(&'static str)` if something goes wrong.
 
-If you not specify `Result` explicitly as return value, it will be added automatically for you by the `decl_module!` macro and `Ok(())` will be returned at the end.
+If you do not specify `Result` explicitly as return value, it will be added automatically for you by the `decl_module!` macro and `Ok(())` will be returned at the end.
 
 Thus, this function definition is equivalent to the above example:
 


### PR DESCRIPTION
Fix `marco` typo.
Clarify that using `config()` is not mandatory to use default storage value.