### PR TITLE
Update installing-substrate.md

### DIFF
--- a/docs/getting-started/installing-substrate.md
+++ b/docs/getting-started/installing-substrate.md
@@ -121,9 +121,6 @@ Then you can build the node with
 # Update your rust toolchain
 ./scripts/init.sh
 
-# Build the wasm runtime
-./scripts/build.sh
-
 # Build the native node
 cargo build
 ```


### PR DESCRIPTION
Remove "./scripts/build.sh" because there is no such file under script folder any more. And wasm runtime is compiled while "cargo build" according to the github readme.