### PR TITLE
Open "users" on a new tab

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -215,7 +215,7 @@ class Index extends React.Component {
       const showcase = siteConfig.users
         .filter(user => user.pinned)
         .map(user => (
-          <a href={user.homepage} key={user.homepage}>
+          <a href={user.homepage} key={user.homepage} target="_blank">
             <img src={user.image} alt={user.name} title={user.name} />
           </a>
         ));

--- a/website/pages/en/users.js
+++ b/website/pages/en/users.js
@@ -30,7 +30,7 @@ class Users extends React.Component {
 
     const editUrl = `${siteConfig.repoUrl}/edit/source/website/data/users.js`;
     const showcase = siteConfig.users.map(user => (
-      <a href={user.homepage} key={user.homepage}>
+      <a href={user.homepage} key={user.homepage} target="_blank">
         <img src={user.image} alt={user.name} title={user.name} />
         <p className="text-dark">{user.name}</p>
       </a>


### PR DESCRIPTION
@Kholostenko suggested we open the website for the different Substrate users in a new tab, hopefully keeping them on substrate.dev longer even if they start clicking away.