### PR TITLE
Update CI config to check each build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,7 +35,7 @@ jobs:
             crowdin --config crowdin.yaml download -b master
             # build and publish website
             cd website && USE_SSH=true GIT_USER=git yarn run publish-gh-pages
-  
+
   check-build:
     docker:
       # specify the version you desire here
@@ -67,3 +67,6 @@ workflows:
           filters: *filter-only-source
     jobs:
       - deploy-website
+  check_build:
+    jobs:
+      - check-build


### PR DESCRIPTION
In https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/issues/222 we agreed that no PRs should be merged into `source` unless the build passes in CI. This PR enables a job which checks the build. Once this goes in, I can require that the build pass in github settings and we can close the issue.

