### PR TITLE
Joshy clarify testnet

### DIFF
--- a/docs/runtime/architecture-of-a-runtime.md
+++ b/docs/runtime/architecture-of-a-runtime.md
@@ -1,6 +1,9 @@
 ---
 title: "Architecture of a Runtime"
 ---
+Bogus bogus bogus bogus
+
+
 Use this diagram to learn and explore the architecture of a runtime. Click on the sections below to be taken to
 documentation about that part of the runtime.
 

--- a/docs/runtime/architecture-of-a-runtime.md
+++ b/docs/runtime/architecture-of-a-runtime.md
@@ -1,9 +1,6 @@
 ---
 title: "Architecture of a Runtime"
 ---
-Bogus bogus bogus bogus
-
-
 Use this diagram to learn and explore the architecture of a runtime. Click on the sections below to be taken to
 documentation about that part of the runtime.
 

--- a/docs/tutorials/start-a-private-network-with-substrate.md
+++ b/docs/tutorials/start-a-private-network-with-substrate.md
@@ -243,8 +243,9 @@ Here are some differences from when we launched as Alice.
 * For the key, I've used the mnemonic phrase that we generated previously. This must be a phrase that corresponds to one of the addresses in your chainspec.
 * The `--chain` flag has changed to use our custom chainspec.
 
-Subsequent validators can now join the network just as Bob did previously. You may bootstrap from _any_ of the nodes already in the network, not just the one that went first.
+Subsequent validators can now join the network as Bob did previously, making sure to use the new chainspec and key. You may bootstrap from _any_ of the nodes already in the network, not just the one that went first.
 
+> All validators must be using identical chain specifications in order to peer together.
 
 Next Steps
 ----------

--- a/website/versioned_docs/version-1.0/tutorials/start-a-private-network-with-substrate.md
+++ b/website/versioned_docs/version-1.0/tutorials/start-a-private-network-with-substrate.md
@@ -245,7 +245,9 @@ Here are some differences from when we launched as Alice.
 * For the key, I've used the mnemonic phrase that we generated previously. This must be a phrase that corresponds to one of the addresses in your chainspec.
 * The `--chain` flag has changed to use our custom chainspec.
 
-Subsequent validators can now join the network just as Bob did previously. You may bootstrap from _any_ of the nodes already in the network, not just the one that went first.
+Subsequent validators can now join the network as Bob did previously, making sure to use the new chainspec and key. You may bootstrap from _any_ of the nodes already in the network, not just the one that went first.
+
+> All validators must be using identical chain specifications in order to peer together.
 
 
 Next Steps

--- a/website/versioned_docs/version-1.0/tutorials/start-a-private-network-with-substrate.md
+++ b/website/versioned_docs/version-1.0/tutorials/start-a-private-network-with-substrate.md
@@ -249,7 +249,6 @@ Subsequent validators can now join the network as Bob did previously, making sur
 
 > All validators must be using identical chain specifications in order to peer together.
 
-
 Next Steps
 ----------
 Congratulations! You've started your own blockchain!


### PR DESCRIPTION
Clarifies language about exactly which options validators joining a testnet should use.

Based on feedback from riot.
![image](https://user-images.githubusercontent.com/2915325/64129993-83649280-cd8d-11e9-9d20-6ef28bd39609.png)
