### PR TITLE
Fix repeated word typo in frontend tutorial

### DIFF
--- a/docs/tutorials/substrate-front-end/part-3-transfer-funds.md
+++ b/docs/tutorials/substrate-front-end/part-3-transfer-funds.md
@@ -44,7 +44,7 @@ export default function Transfer (props) {
 
 We will then create our function to actually submit the form. To do so we need to create the transaction, then sign it with our private key, and finally send it. The `api` provides all we need here again, with `api.tx.balances` and the `transfer` and `signAndSend` methods. The latter takes the key pair as the first parameter and a callback as the second parameter.
 
-The the `status` of the transaction is passed to the callback function. We will use it to see if our transaction is executed successfully. In the example below, we will show our users if the transaction was successfully finalized using the `isFinalized` status value. If it was successfullu executed, we're showing at which block it was finalized.
+The `status` of the transaction is passed to the callback function. We will use it to see if our transaction is executed successfully. In the example below, we will show our users if the transaction was successfully finalized using the `isFinalized` status value. If it was successfullu executed, we're showing at which block it was finalized.
 
 ```js
 const makeTransfer = () => {


### PR DESCRIPTION
Fix typo
`The the status ...` -> `The status ...`