### PR TITLE
Ben remove blast

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -16,68 +16,6 @@
 
 const React = require("react");
 
-class Blast extends React.Component {
-  render() {
-    // FIXME: Doccusaurus v1 doesn't allow  for themes or customisation yet
-    // so we have to inline some styles to move our element to top
-    let cfg = this.props.config;
-    return (
-      <div>
-        <style
-          dangerouslySetInnerHTML={{
-            __html: `
-#blast {
-  display: block;
-  position: fixed;
-  width: 100%;
-  top: 0;
-  height: 50px;
-  background: #ff1864 ${cfg.background};
-  color: white;
-  z-index: 99999;
-}
-
-#blast h2 {
-  margin: 0;
-  line-height: 45px;
-  text-align: center;
-}
-
-#blast a {
-  color: white;
-  text-decoration: underline;
-}
-
-body {
-  // let's give it a minimal animation
-  transition: ease 1.5s;
-  margin-top: 50px;
-}
-@media only screen and (min-width: 1024px) {
-  .docsNavContainer {
-    height: calc(100vh - 100px);
-    top: 100px;
-  }
-
-  .onPageNav {
-    max-height: calc(100vh - 140px);
-    top: 140px;
-  }
-}
-`
-          }}
-        />
-        <section id="blast">
-          <h2>
-            {cfg.intro}
-            <a href={cfg.link}>{cfg.label}</a>
-          </h2>
-        </section>
-      </div>
-    );
-  }
-}
-
 class Footer extends React.Component {
   docUrl(doc, language) {
     const baseUrl = this.props.config.baseUrl;
@@ -93,10 +31,8 @@ class Footer extends React.Component {
   }
 
   render() {
-    let blast = this.props.config.blast;
     return (
       <footer className="nav-footer" id="footer">
-        {blast ? <Blast config={blast} /> : ""}
         <section className="sitemap">
           <a href={this.props.config.baseUrl} className="nav-home">
             {this.props.config.footerIcon && (

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -42,6 +42,7 @@ const siteConfig = {
 
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
+    { href: "/hacktoberfest/", label: "Hacktoberfest", class: "hacktoberfest" },
     { page: "docs", label: "Docs" },
     { href: "/rustdocs/v1.0/", label: "Reference Docs" },
     { page: "tutorials", label: "Tutorials" },
@@ -149,14 +150,6 @@ const siteConfig = {
       facetFilters: ["language:LANGUAGE"]
     }
   },
-
-  // customised blast banner on top
-  blast: {
-    intro: "Hacktoberfest is here! ",
-    link: "https://substrate.dev/hacktoberfest",
-    label: "Hack with us",
-    background: "url(/img/hacktoberfest-blast-bg.png); background-size: cover;"
-  }
 };
 
 module.exports = siteConfig;

--- a/website/static/css/custom.css
+++ b/website/static/css/custom.css
@@ -67,6 +67,12 @@
     padding: 0;
 }
 
+.headerWrapper ul li a[href="/hacktoberfest/"] {
+  text-transform: uppercase;
+  margin-right: 1em;
+  font-weight: bold;
+}
+
 /* Fix search icon in search box */
 .navSearchWrapper::before {
     box-sizing: unset;


### PR DESCRIPTION
based off #276

this removes the blast and all the mess we did with the css and instead opt for a slightly highlighted menu item:

![image](https://user-images.githubusercontent.com/40496/66055757-4d563200-e536-11e9-8b7c-f45e854a4a61.png)

Merge whenever we find yet another issue with the blast - but only if so.