### PR TITLE
Updated adding-a-module-to-runtime tutorial and minor words update

### DIFF
--- a/docs/development/module/macros.md
+++ b/docs/development/module/macros.md
@@ -28,7 +28,7 @@ Each of these macros have their own page which describes how to use them.
 
 ## Expanding the Macros
 
-The runtime macros do a lot work for you, and as a result, may sometimes feel like magic. In general, we suggest that you treat them like magic.
+The runtime macros do a lot of work for you, and as a result, may sometimes feel like magic. In general, we suggest that you treat them like magic.
 
 However, if you are interested in learning more details about what exactly the macros do, you can expand them with [`cargo expand`](https://github.com/dtolnay/cargo-expand), resulting in pure Rust code.
 

--- a/docs/development/module/storage.md
+++ b/docs/development/module/storage.md
@@ -2,7 +2,7 @@
 title: Runtime Storage
 ---
 
-Runtime storage allows you to store data in your blockchain which can be accessed from from your runtime logic and persists between blocks.
+Runtime storage allows you to store data in your blockchain which can be accessed from your runtime logic and persists between blocks.
 
 ## Storage Items
 
@@ -25,7 +25,7 @@ You can use the `decl_storage!` macro to easily create new runtime storage items
 ```rust
 decl_storage! {
 	trait Store for Module<T: Trait> as Example {
-		pub SomeValue: u64; 
+		pub SomeValue: u64;
 		pub SomeMap: map u64 => u64;
 		pub SomeLinkedMap: linked_map u64 => u64;
 		pub SomeDoubleMap: double_map u64, blake2_256(u64) => u64;

--- a/docs/tutorials/adding-a-module-to-your-runtime.md
+++ b/docs/tutorials/adding-a-module-to-your-runtime.md
@@ -74,7 +74,7 @@ std = [
 ]
 ```
 
-This second line aaa defines the `default` features of your runtime crate as `std`. You can imagine, each module crate has a similar configuration defining the default feature for the crate. Your feature will determine the features that should be used on downstream dependencies. For example, the snippet above should be read as:
+This second line defines the `default` features of your runtime crate as `std`. You can imagine, each module crate has a similar configuration defining the default feature for the crate. Your feature will determine the features that should be used on downstream dependencies. For example, the snippet above should be read as:
 
 > The default feature for this Substrate runtime is `std`. When `std` feature is enabled for the runtime, `parity-scale-codec`, `primitives`, `client`, and all the other listed dependencies should use their `std` feature too.
 


### PR DESCRIPTION
Update in two files under `module` are trivial.

Today I walked through adding-a-module-to-runtime tutorial. Some codes doesn't compile, and some are not so clear. So the tutorial is also updated.