### PR TITLE
update `Creating a Runtime Module` tutorial

### DIFF
--- a/docs/tutorials/creating-a-runtime-module.md
+++ b/docs/tutorials/creating-a-runtime-module.md
@@ -336,5 +336,24 @@ code in their runtime's `Cargo.toml` files and updating their runtime's `lib.rs`
 
 In this tutorial, you've learned to create a runtime module as a Rust crate.
 You're now ready to replace the template logic with your own. If you're not sure
-what to code, check out [one of our tutorials](https://substrate.dev/en/tutorials).
+what to code, check out the following.
 
+### Learn More
+
+- We have [plenty of tutorials](https://substrate.dev/en/tutorials) to showcase
+Substrate development concepts and techniques.
+- To learn more about writing your own runtime with a front end, we have a
+[Substrate Collectables Workshop](https://substrate.dev/substrate-collectables-workshop)
+for building an end-to-end application.
+- For more information about runtime development tips and patterns, refer to our
+[Substrate Recipes](https://substrate.dev/recipes/).
+
+### Examples
+
+- Tutorial on [adding a `Contracts` module into runtime](tutorials/adding-a-module-to-your-runtime),
+so your node can run smart contract.
+
+### References
+
+- [The Cargo book](https://doc.rust-lang.org/stable/cargo/)
+- More about [Rust and WebAssembly](https://rustwasm.github.io/)

--- a/docs/tutorials/creating-a-runtime-module.md
+++ b/docs/tutorials/creating-a-runtime-module.md
@@ -2,46 +2,69 @@
 title: "Creating a Runtime Module"
 ---
 
-In this tutorial, you'll write a Substrate runtime module that lives in its own crate, and include it in a node based on the node-template.
+In this tutorial, you'll write a Substrate runtime module that lives in its own
+crate, and include it in a node based on the node-template.
 
 ## Setup Your Development Environment
 
-If you haven't already, follow the [fast installation](getting-started/installing-substrate.md#fast-installation) for getting started on Substrate. It will provide you with all the development resources you need to build Substrate and the [`substrate-up` scripts](getting-started/using-the-substrate-scripts) for quickly setting up new nodes.
+If you haven't already, follow the
+[fast installation](getting-started/installing-substrate#fast-installation) for
+getting started on Substrate. It will provide you with all the development
+resources you need to build Substrate and the
+[`substrate-up` scripts](getting-started/using-the-substrate-scripts) for
+quickly setting up new nodes.
 
-## Create your Node
+### Cloning Node and Module Template to Start
 
-We'll begin by creating a brand new node template. If you've followed other runtime tutorials, you've probably started this way before:
-
-```bash
-substrate-node-new modular-chain <your name>
-```
-
-In this tutorial, we're not going to write our module directly as part of the node template, but rather as a separate Rust crate. This approach provides a few advantages:
+We're not going to write our module directly as part of the node template, but
+rather as a separate Rust crate. This approach provides a few advantages:
 
 1. Our module can be easily imported into other nodes in the future.
-2. Our module can be published to places like GitHub or Crates.io without publishing our entire node in the same place.
+2. Our module can be published to places like GitHub or Crates.io without
+publishing our entire node in the same place.
 
-However, we do still need to set up a Substrate node to actually run our module.
+However, to effectively develop and test with your own runtime module, you need
+to first setup a single-node Substrate blockchain. Then inside the node runtime
+add in your own additional module.
 
-## Clone the Module Template Repository
-
-So if our module isn't going to live in the node template, where _is_ it going to live?
-
-If you aren't familiar with creating Rust libraries or using them in other Rust projects, you can get a more in-depth explanation by reading [the Cargo book](https://doc.rust-lang.org/cargo/guide/creating-a-new-project.html).
-
-While it's perfectly possible to create a new Substrate runtime module from scratch, the fastest way to get started is to clone a Substrate module template we have created for you:
+We'll begin from cloning the necessary repositories:
 
 ```bash
-git clone https://github.com/shawntabrizi/substrate-module-template
+cd my-playground-folder
+# cloning from a standard node template
+git clone https://github.com/substrate-developer-hub/substrate-node-template.git my-node
+# cloning from a standard module template
+git clone https://github.com/substrate-developer-hub/substrate-module-template.git my-module
+
+# kicking off the node compilation
+cd my-node
+cargo build --release
 ```
 
-In the `Cargo.toml` file, update the module's name and authorship to something meaningful. In this tutorial we're focusing on how to create and use the module rather than writing interesting module logic, so I'll call mine `test_module`. The beginning of my `Cargo.toml` now looks like.
+The compilation of the node may take up to 30 minutes, depending on your hardware.
+So let us kickstarted it first.
+
+Now, if our module isn't going to live in the node template, where _is_ it going
+to live? If you aren't familiar with creating Rust libraries or using them in
+other Rust projects, you can get a more in-depth explanation by reading
+[the Cargo book](https://doc.rust-lang.org/cargo/guide/creating-a-new-project.html).
+
+While it's perfectly possible to create a new Substrate runtime module from
+scratch, the fastest way is to clone from a Substrate module template, as we
+have just done above.
+
+In the `Cargo.toml` file, update the module's name and authorship to something
+meaningful. In this tutorial we're focusing on how to create and use the module
+rather than writing interesting module logic, so let's call it `test_module`.
+The beginning of the `Cargo.toml` now looks like:
+
+**`my-module/Cargo.toml`**
 
 ```toml
 [package]
 name = "test_module"
 version = "0.1.0"
-authors = ["Joshy Orndorff"]
+authors = ["Your Name"]
 edition = "2018"
 ```
 
@@ -51,177 +74,249 @@ You should be able to successfully compile this template module with:
 cargo build
 ```
 
-Let's explore some of the things we did for you in this Substrate module template. We will start by looking at the `Cargo.toml` file.
+Let's explore some of the things Substrate module template do for us, starting
+from the `Cargo.toml` file.
+
+## Development
 
 ### Your Module's `std` Feature
 
-In your `Cargo.toml` file, you will notice a few lines about the "`std` feature". In Rust, when you enable `std`, you give your project access to [the Rust standard libraries](https://doc.rust-lang.org/std/). This works just fine when building native binaries.
+In your `my-module/Cargo.toml` file, you will notice a few lines about the
+"`std` feature". In Rust, when you enable `std`, you give your project access to
+[the Rust standard libraries](https://doc.rust-lang.org/std/). This works just
+fine when building native binaries.
 
-However, Substrate also builds the runtime code to Wasm. In this case we use cargo features to disable the Rust standard library when compiling for Wasm because [wasm-unknown-unknown](https://github.com/rust-lang/rust/pull/45905) does not know which allocator to use.
+However, Substrate also builds the runtime code to WebAssembly(Wasm). In this
+case we use cargo features to disable the Rust standard library when compiling
+for Wasm because the compiler does not know which allocator to use. See
+Reference section for the details.
 
-Thus, all the dependencies we use for our module, and our entire runtime, must be able to compile with [`no_std`](https://rust-embedded.github.io/book/intro/no-std.html). Our `Cargo.toml` file tells our module's dependencies to only use their `std` feature when this module also uses its `std` feature like so:
+Thus, all the dependencies we use for our module, and our entire runtime, must
+be able to compile with
+[`no_std`](https://rust-embedded.github.io/book/intro/no-std.html) feature.
+Our `Cargo.toml` file tells our module's dependencies to only use their `std`
+feature when this module also uses its `std` feature like so:
 
-```toml
+**`my-module/Cargo.toml`**
+
+```TOML
 [features]
 default = ['std']
 std = [
-    'parity-codec/std',
+    'serde',
+    'codec/std',
     'support/std',
     'system/std',
+    'sr-primitives/std',
+    'runtime-io/std',
 ]
 ```
 
 > In general, when adding dependencies to your runtime, follow this pattern.
 >
 > 1. Add a feature called `std`
-> 2. Enable this feature by default in your Cargo.toml
-> 3. When compiling for Wasm, the feature is disabled
+> 2. Enable this feature by default in your `Cargo.toml`
+> 3. When compiling for Wasm, disable the feature
 
 ### Consistent Substrate Dependencies
 
-All Substrate modules will depend on some low level module libraries such as `srml-system` and `srml-support`. These libraries are pulled from the main Substrate GitHub repository. When people build their own Substrate nodes, they will also have dependencies on the main Substrate repository.
+All Substrate modules will depend on some low-level module libraries such as
+`srml-system` and `srml-support`. These libraries are pulled from the main
+Substrate GitHub repository. When people build their own Substrate nodes, they
+will also have dependencies on the main Substrate repository.
 
-Because of this, you will need to be careful to ensure consistent dependencies from your module and the node integrating your module to the Substrate repository. If your module is dependent on one version of Substrate, and the node is dependent on another, compilation will run into errors where the Substrate versions may be incompatible, or the two versions of the same library are being used. Ultimately Cargo will not be able to resolve those conflicts and you will get a compile time error.
+Because of this, you will need to be careful to ensure consistent dependencies
+from your module and the node integrating your module to the Substrate
+repository. If your module is dependent on one version of Substrate, and the
+node is dependent on another, compilation will run into errors where the
+Substrate versions may be incompatible, or the two versions of the same library
+are being used. Ultimately Cargo will not be able to resolve those conflicts
+and you will get a compile time error.
 
 So when building your module have two options:
 
-**Option 1 (recommended)**
+**Option 1**
 
-Develop against the `v1.0` branch as the template demonstrates. In this case you will need to update your node template's `Cargo.toml` to depend on Substrate's `branch = 'v1.0'` like the module template currently does, rather than `rev = <git commit hash>`. This will ensure that your module can be used by any node who is also based on the `v1.0` branch
+If you prefer to have the freshly-baked features from Substrate, you can develop
+your module against a specific git commit of Substrate. In future to upgrade,
+you can update to a newer git commit of Substrate, recompile and test your
+module against the runtime, and then release your module.
 
-**Option 2**
+In this case you change the Substrate module `Cargo.toml` to use
+`rev = <git commit hash>`, e.g.:
 
-It is also acceptable to develop your module for a specific git commit. In this case you'll need to change the Substrate module template's `Cargo.toml` to use `rev = <git commit hash>` rather than `branch = 'v1.0'`. This means that only nodes which use the exact same git commit hash for their project can use your module.
+```TOML
+#--snip--
 
-If you follow our recommended option 1, your dependency definitions will look like:
-
-```toml
-# This dependency is published on crates.io so just use a version
-[dependencies.parity-codec]
-default-features = false
-features = ['derive']
-version = '3.5'
-
-# These dependencies specify a git branch
 [dependencies.support]
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
 package = 'srml-support'
-branch = 'v1.0'
+rev = '3dedd246c62255ba6f9b777ecba318dfc2078d85'
 
-[dependencies.system]
+#--snip--
+```
+
+This means that only nodes which use the exact same git commit hash for their
+projects can use your module.
+
+**Option 2**
+
+If you prefer to have more stability, you can develop your module against
+Substrate's known release tags (e.g.
+[`v1.0.0`](https://github.com/paritytech/substrate/tree/v1.0.0)). In this case
+you will need to update your node template's `Cargo.toml` to depend on
+Substrate's `tag = 'v1.0.0'`, e.g.:
+
+```TOML
+#--snip--
+
+[dependencies.support]
 default_features = false
 git = 'https://github.com/paritytech/substrate.git'
-package = 'srml-system'
-branch = 'v1.0'
-# Could also use a specific revision
-# rev = '<commit hash>'
+package = 'srml-support'
+tag = 'v1.0.0'
+
+#--snip--
 ```
 
 ### Your Module's Dev Dependencies
 
-The final section of the `Cargo.toml` file specifies the dev dependencies. These are the dependencies that are needed in your module's tests, but not necessary the actual module itself.
+The final section of the `Cargo.toml` file specifies the dev dependencies.
+These are the dependencies that are needed in your module's tests, but not
+necessary the actual module itself.
 
-
-```toml
+```TOML
+#--snip--
 
 [dev-dependencies.primitives]
 git = 'https://github.com/paritytech/substrate.git'
 package = 'substrate-primitives'
-branch = 'v1.0'
-
-[dev-dependencies.runtime-primitives]
-git = 'https://github.com/paritytech/substrate.git'
-package = 'sr-primitives'
-branch = 'v1.0'
-
-[dev-dependencies.runtime-io]
-git = 'https://github.com/paritytech/substrate.git'
-package = 'sr-io'
-branch = 'v1.0'
+rev = '3dedd246c62255ba6f9b777ecba318dfc2078d85'
 ```
 
-You can confirm for yourself that the Substrate module template's test passes with:
+You can confirm for yourself that the Substrate module template's test passes
+with:
 
 ```bash
 cargo test
 ```
 
-> Optional: You can remove these dev dependencies from your `Cargo.toml` file and confirm that the module still compiles with `cargo build`. However, you will notice that `cargo test` does not compile! If you do this experiment, remember to restore the dev dependencies afterward.
+> Optional: You can remove these dev dependencies from your `Cargo.toml` file
+> and confirm that the module still compiles with `cargo build`. However, you
+> will notice that `cargo test` does not compile!
+>
+> If you do this experiment, remember to restore the dev dependencies afterward.
 
-It will take a little experimentation to gain familiarity with what dependencies you need for each module you dream up. So the take-away from this section is not that `Cargo.toml` should always look like it does in the template. Rather, `Cargo.toml` needs to have the correct dependencies and you now know how to specify them.
+It will take a little experimentation to gain familiarity with what dependencies
+you need for each module you dream up. So the take-away is not that `Cargo.toml`
+should always look like it does in the template. Rather, `Cargo.toml` needs to
+have the correct dependencies and you now know how to specify them.
 
-## Add your Runtime Module to your Node
+### Add your Runtime Module to your Node
 
-With our runtime module now compiling and passing it's test, we're ready to add it to our node template.
+With our runtime module now compiling and passing it's test, we're ready to add
+it to our node.
 
-First we need to add our newly-created crate as a dependency in the node runtime's `Cargo.toml`.
+Continued working in your playground folder, we first need to add our
+newly-created crate as a dependency in the node runtime's `Cargo.toml`. Then we
+need to tell the module to only build its `std` feature when the runtime itself
+does, as followed:
 
-```toml
+**`my-node/runtime/Cargo.toml`**
+
+```TOML
+#--snip--
+
 [dependencies.test_module]
 default_features = false
-path = "../../test_module"
-```
+path = "../../my-module"
 
-> You **must** set `default_features = false` so that your runtime will successfully compile to wasm.
-
-And just as before, we need to tell the module to only build its `std` feature when the runtime itself does.
-```toml
+# toward the bottom
+[features]
+default = ['std']
 std = [
-  ...
-  'test_module/std',
+    'test_module/std',
+    #--snip--
 ]
 ```
 
-Next we'll update `runtime/lib.rs` in `modular-chain` to actually use our new runtime module. The lines that bring in the template module that is coded directly in the node runtime are still there, so we just need to update them in three places.
+> You **must** set `default_features = false` so that your runtime will
+successfully compile to wasm.
 
-1. Remove `mod template` as we've already brought that dependency in via `Cargo.toml`
-2. Update the trait implementation
+Next we'll update `runtime/src/lib.rs` to actually use our new runtime module.
+We will update the trait implementation with our `test_module` and add it in
+our runtime construction macro.
+
+**`my-node/runtime/src/lib.rs`**
+
 ```rust
-/// Used for the module test_module
+// already existed
+impl template::Trait for Runtime {
+  type Event = Event;
+}
+
+// add the following code block
 impl test_module::Trait for Runtime {
 	type Event = Event;
 }
+
+//...
+construct_runtime!(
+  pub enum Runtime where
+    Block = Block,
+    NodeBlock = opaque::Block,
+    UncheckedExtrinsic = UncheckedExtrinsic
+  {
+    //...
+    // add the following line
+    TestModule: test_module::{Module, Call, Storage, Event<T>},
+  }
+);
 ```
 
-3. Update `construct_runtime`
-```rust
-TestModule: test_module::{Module, Call, Storage, Event<T>},
-```
+### Appreciate your Work 😊
 
-## Appreciate your Work
-At this point you have the template module packaged up as it's own crate, and included in your `modular-chain` runtime.
+At this point you have the module packaged up as it's own crate, and included in
+your node runtime. Compile and run your node with:
 
-Build the `modular-chain` node with
 ```bash
-./scripts/build.sh
+cd my-playground-folder/my-node
+# compiling your node
 cargo build --release
+# purge any existing chain
+cargo run --release -- purge-chain --dev
+# start the node
+cargo run --release -- --dev
 ```
 
-And run your node with
-```bash
-# Clear the data directory in case you've done this before
-./target/release/modular-chain purge-chain --dev
+Finally, start the [Polkadot apps UI](https://polkadot.js.org/apps/#/explorer)
+to confirm that the module is working as expected. In the apps UI, you will need
+to navigate to the `Settings` tab, and have the `remote node/endpoint to connect to`
+set to `Local Node`.
 
-# Start the chain
-./target/release/modular-chain --dev
-```
+### Publish your Module
 
-Finally, start the [Apps UI](https://polkadot.js.org/apps/#/explorer) to confirm that the module is working as expected. If you aren't familiar with the Apps UI, you will need to navigate to the settings tab, and select 'Local Node'.
+Once your module is no longer just testing code, you should consider publishing
+it. We'll cover publishing your module to GitHub here, but [crates.io](https://crates.io/)
+is another good option. Go ahead and
+[create a GitHub repository](https://help.github.com/en/articles/create-a-repo)
+and [push your module's code](https://help.github.com/en/articles/pushing-to-a-remote)
+to it.
 
-## Customize your Module
-So far in this tutorial you've learned to create a runtime module as a Rust crate. You're now ready to replace the template logic with your own. If you're not sure what to code, check out one of our runtime modules in [tutorials](https://substrate.dev/en/tutorials).
+With the code on GitHub, your module is properly published. Congratulations! We
+now need to update your node to use the code that is on GitHub instead of a
+hard-coded file system path.
 
-## Publish your Module
-Once your module is no longer just a template, you should consider publishing it. We'll cover publishing your module to GitHub here, but Crates.io is another good option. Go ahead and [create a GitHub repository](https://help.github.com/en/articles/create-a-repo) and [push your module's code](https://help.github.com/en/articles/pushing-to-a-remote) to it.
+The final edit to your runtime's `Cargo.toml` file will update its dependency
+on your module. The new code is:
 
-With the code on GitHub, your module is properly published. Congratulations! We now need to update your node to use the code that is on GitHub instead of a hard-coded file system path.
+**`my-node/runtime/Cargo.toml`**
 
-The final edit to your runtime's `Cargo.toml` file will update its dependency on your module. The new code is
-```toml
-[dependencies.<your-module-name>]
+```TOML
+[dependencies.your-module-name]
 default_features = false
-git = "https://github.com/<you>/<your-module>"
+git = "https://github.com/your-username/your-module"
 branch = "master"
 
 # You may choose a specific commit or tag instead of branch
@@ -229,6 +324,17 @@ branch = "master"
 # tag = "<some tag>"
 ```
 
-Compile one more time and notice that Cargo now grabs your module from GitHub instead of using the local files.
+Compile one more time and notice that Cargo now grabs your module from GitHub
+instead of using the local files.
 
-Congratulations! You've written a Substrate runtime module in its own Rust crate, and published that crate to GitHub. Other blockchain developers can now easily use your module in their runtime by simply including those same four lines of code in their runtime's `Cargo.toml` files and updating their runtime's `lib.rs` file.
+Congratulations! You've written a Substrate runtime module in its own Rust crate,
+and published that crate to GitHub. Other blockchain developers can now easily
+use your module in their runtime by simply including those same four lines of
+code in their runtime's `Cargo.toml` files and updating their runtime's `lib.rs` file.
+
+## Next Steps
+
+In this tutorial, you've learned to create a runtime module as a Rust crate.
+You're now ready to replace the template logic with your own. If you're not sure
+what to code, check out [one of our tutorials](https://substrate.dev/en/tutorials).
+

--- a/docs/tutorials/creating-a-runtime-module.md
+++ b/docs/tutorials/creating-a-runtime-module.md
@@ -3,56 +3,68 @@ title: "Creating a Runtime Module"
 ---
 
 In this tutorial, you'll write a Substrate runtime module that lives in its own
-crate, and include it in a node based on the node-template.
+crate, and include it in a node based on the `substrate-node-template`.
 
-## Setup Your Development Environment
+## Prerequisites
 
-If you haven't already done so, follow the
-[Getting Started](getting-started) guide to download necessary tools to
-build Substrate.
+If you haven't already done so, follow the [Getting Started](getting-started.md)
+guide to download necessary tools to build Substrate.
 
-### Cloning the Node and Module Template
+### Clone the Node and Module Template
 
 We're not going to write our module directly as part of the node template, but
-rather as a separate Rust crate. This approach provides a few advantages:
+rather as a separate Rust crate. This approach allows us to publish our module
+separate from our node and also allows other to easily import this module into
+their own Substrate runtime.
 
-1. Our module can be easily imported into other nodes in the future.
-2. Our module can be published to GitHub without publishing our entire node.
+1. Clone the Substrate node template:
 
-However, to effectively develop and test with your own runtime module, you need
-to first setup a single-node Substrate blockchain. Then inside the node runtime
-add in your own additional module.
+    ```bash
+    git clone https://github.com/substrate-developer-hub/substrate-node-template.git my-node
+    ```
 
-We'll begin from cloning the necessary repositories:
+2. Clone the Substrate module template:
+
+    ```bash
+    git clone https://github.com/substrate-developer-hub/substrate-module-template.git my-module
+    ```
+
+3. Build the Substrate node template:
+
+    ```bash
+    cd my-node
+    cargo build --release
+    ```
+
+The `substrate-node-template` contains a working Substrate node, and the
+`substrate-module-template` contains an independent Rust crate which is a
+Substrate runtime module that can be included in your node. The compilation of
+the node may take up to 30 minutes depending on your hardware, so let that run
+while you continue to follow this guide.
+
+If you aren't familiar with Rust including and using other modules, you can
+refer to [the Cargo
+book](https://doc.rust-lang.org/cargo/guide/creating-a-new-project.html) for a
+more in-depth explanation.
+
+## The Substrate Module Template
+
+You should be able to successfully compile the Substrate module template with:
 
 ```bash
-mkdir tutorial
-cd tutorial
-git clone https://github.com/substrate-developer-hub/substrate-node-template.git my-node
-git clone https://github.com/substrate-developer-hub/substrate-module-template.git my-module
-
-# kick-start the node compilation
-cd my-node
+cd my-module
 cargo build --release
 ```
 
-The compilation of the node may take up to 30 minutes depending on your hardware,
-so we have kick-started it.
+Let's explore the Substrate module template, starting with the `Cargo.toml`
+file.
 
-We have just cloned from two repositories because `substrate-node-template`
-contains the necessary code to run your Substrate node, and
-`substrate-module-template` contains the module code to be included in your node.
-If you aren't familiar with Rust including and using other modules, you can refer
-to [the Cargo book](https://doc.rust-lang.org/cargo/guide/creating-a-new-project.html)
-for a more in-depth explanation.
+### Renaming Your Crate
 
-While it's perfectly possible to create a new Substrate runtime module from
-scratch, the easiest way is to clone from a Substrate module template, as we
-have done above.
+In the `Cargo.toml` file, you can update the crate's name and authorship. In
+this tutorial, we're focusing on how to create and use the module rather than
+writing interesting module logic. So let's call it `test_module`.
 
-In the `Cargo.toml` file, update the module's name and authorship to something
-meaningful. In this tutorial we're focusing on how to create and use the module
-rather than writing interesting module logic, so let us call it `test_module`.
 The beginning of the `Cargo.toml` now looks like:
 
 **`my-module/Cargo.toml`**
@@ -64,17 +76,6 @@ version = "0.1.0"
 authors = ["Your Name"]
 edition = "2018"
 ```
-
-You should be able to successfully compile this template module with:
-
-```bash
-cargo build --release
-```
-
-Let's explore some of the things Substrate module template do for us, starting
-from the `Cargo.toml` file.
-
-## Development
 
 ### Your Module's `std` Feature
 
@@ -104,13 +105,6 @@ std = [
     'runtime-io/std',
 ]
 ```
-
-> **Note:** In general, when adding dependencies to your runtime, follow this
-> pattern.
->
-> 1. Add a feature called `std`
-> 2. Enable this feature by default in your `Cargo.toml`
-> 3. When compiling for Wasm, disable the feature
 
 ### Consistent Substrate Dependencies
 
@@ -153,9 +147,9 @@ branch = 'v2.0'
 
 ### Your Module's Dev Dependencies
 
-The final section of the `Cargo.toml` file specifies the dev dependencies.
-These are the dependencies that are needed in your module's tests, but not
-necessary the actual module itself.
+The final section of the `Cargo.toml` file specifies the dev dependencies. These
+are the dependencies that are needed in your module's tests, but not necessary
+the actual module itself.
 
 **`my-module/Cargo.toml`**
 
@@ -168,26 +162,22 @@ package = 'substrate-primitives'
 branch = 'v2.0'
 ```
 
-You can confirm that the Substrate module template's test passes with:
+You can confirm that the tests in the Substrate module template pass with:
 
 ```bash
 cargo test
 ```
 
-It will take a little experimentation to gain familiarity with what dependencies
-you need for each module you dream up. So the take-away is not that `Cargo.toml`
-should always look like it does in the template. Rather, `Cargo.toml` needs to
-have the correct dependencies and you now know how to specify them.
+You may need to modify the dependencies you need for the modules you create.
 
-### Add Your Runtime Module to Your Node
+## Add Your Runtime Module to Your Node
 
-With our runtime module now compiling and passing it's test, we're ready to add
+With our runtime module now compiling and passing it's tests, we're ready to add
 it to our node.
 
-Continued working in your `tutorial` folder, we first add our
-newly-created crate as a dependency in the node runtime's `Cargo.toml`. Then we
-tell the module to only build its `std` feature when the runtime itself
-does, as followed:
+We first add our newly-created crate as a dependency in the node's runtime
+`Cargo.toml`. Then we tell the module to only build its `std` feature when the
+runtime itself does, as follows:
 
 **`my-node/runtime/Cargo.toml`**
 
@@ -208,23 +198,18 @@ std = [
 ```
 
 > You **must** set `default_features = false` so that your runtime will
-successfully compile to wasm.
+successfully compile to Wasm.
 
 Next we will update `my-node/runtime/src/lib.rs` to actually use our new runtime
 module, by adding a trait implementation with our `test_module` and add it in
-our runtime construction macro.
+our `construct_runtime!` macro.
 
 **`my-node/runtime/src/lib.rs`**
 
 ```rust
-// already existed
-impl template::Trait for Runtime {
-  type Event = Event;
-}
-
 // add the following code block
 impl test_module::Trait for Runtime {
-	type Event = Event;
+  type Event = Event;
 }
 
 // --snip--
@@ -241,37 +226,44 @@ construct_runtime!(
 );
 ```
 
-### Appreciate Your Work 😊
+## Run Your Node
 
-At this point you have the module packaged up as it's own crate, and included it
-in your node runtime. Compile and run your node with:
+At this point you have the module packaged up as it's own crate and included in
+your node's runtime.
 
-```bash
-cd tutorial/my-node
-cargo build --release
+1. Compile and run your node with:
 
-# Purge any existing chain. Enter `y` on prompt.
-./target/release/node-template purge-chain --dev
+    ```bash
+    cd my-node
+    cargo build --release
+    ```
 
-# Start the node
-./target/release/node-template --dev
-```
+2. Purge any existing dev chain (Enter `y` on prompt):
 
-Finally, start the
-[Polkadot-JS Apps connecting to your local node](https://polkadot.js.org/apps/#/explorer?rpc=ws://127.0.0.1:9944)
-to confirm that the module is working as expected.
+    ```bash
+    ./target/release/node-template purge-chain --dev
+    ```
+
+3. Start your node:
+
+    ```bash
+    ./target/release/node-template --dev
+    ```
+
+Finally, start the [Polkadot-JS Apps connecting to your local
+node](https://polkadot.js.org/apps/#/explorer?rpc=ws://127.0.0.1:9944) to
+confirm that the module is working as expected.
 
 > **Notes:** You can also manually set the node URL in Polkadot-JS Apps by
-navigating to the **Settings** tab, and have the **remote node/endpoint to connect
-to** set to **Local Node**.
+navigating to the **Settings** tab, and have the **remote node/endpoint to
+connect to** set to **Local Node**.
 
-### Publish Your Module
+## Publish Your Module
 
 Once your module is no longer just testing code, you should consider publishing
-it to GitHub. Go ahead and
-[create a GitHub repository](https://help.github.com/en/articles/create-a-repo)
-and [push your module's code](https://help.github.com/en/articles/pushing-to-a-remote)
-to it.
+it to GitHub. Go ahead and [create a GitHub
+repository](https://help.github.com/en/articles/create-a-repo) and [push your
+module's code](https://help.github.com/en/articles/pushing-to-a-remote) to it.
 
 With the code on GitHub, your module is properly published. Congratulations! Now
 we just need to update your node to use the code that is on GitHub instead of a
@@ -294,32 +286,32 @@ branch = "master"
 Compile one more time and notice that Cargo now grabs your module from GitHub
 instead of using the local files.
 
-Congratulations! You've written a Substrate runtime module in its own Rust crate,
-and published that crate to GitHub. Other blockchain developers can now easily
-use your module in their runtime by simply including those same four lines of
-code in their runtime's `Cargo.toml` files and updating their runtime's `lib.rs`
-file.
-
 ## Next Steps
 
-In this tutorial, you've learned to create a runtime module as a Rust crate.
-You're now ready to replace the template logic with your own. If you're not sure
-what to code, check out the following.
+Congratulations! You've written a Substrate runtime module in its own Rust
+crate, and published that crate to GitHub. Other blockchain developers can now
+easily use your module in their runtime by simply including those same four
+lines of code in their runtime's `Cargo.toml` files and updating their runtime's
+`lib.rs` file.
+
+If you're not sure what to do next, check out the resources below.
 
 ### Learn More
 
 - We have [plenty of tutorials](https://substrate.dev/en/tutorials) to showcase
-Substrate development concepts and techniques.
+  Substrate development concepts and techniques.
 - To learn more about writing your own runtime with a front end, we have a
-[Substrate Collectables Workshop](https://substrate.dev/substrate-collectables-workshop)
-for building an end-to-end application.
+  [Substrate Collectables
+  Workshop](https://substrate.dev/substrate-collectables-workshop) for building
+  an end-to-end application.
 - For more information about runtime development tips and patterns, refer to our
-[Substrate Recipes](https://substrate.dev/recipes/).
+  [Substrate Recipes](https://substrate.dev/recipes/).
 
 ### Examples
 
-- Tutorial on [adding a `Contracts` module into runtime](tutorials/adding-a-module-to-your-runtime),
-so your node can run smart contract.
+- Tutorial on [adding a `Contracts` module into
+  runtime](tutorials/adding-a-module-to-your-runtime), so your node can run
+  smart contract.
 
 ### References
 

--- a/docs/tutorials/creating-a-runtime-module.md
+++ b/docs/tutorials/creating-a-runtime-module.md
@@ -139,7 +139,8 @@ git = 'https://github.com/paritytech/substrate.git'
 package = 'srml-support'
 branch = 'v2.0'
 
-# To develop against a specific git commit, use:
+# Develop against a git commit by specifying the same Substrate commit as your main node. 
+# It is important to use the same Substrate commit to prevent dependencies mismatch.
 # rev = "<some commit hash>"
 
 # --snip--

--- a/docs/tutorials/creating-a-runtime-module.md
+++ b/docs/tutorials/creating-a-runtime-module.md
@@ -140,7 +140,7 @@ package = 'srml-support'
 branch = 'v2.0'
 
 # To develop against a specific git commit, use:
-# rev = '3dedd246c62255ba6f9b777ecba318dfc2078d85'
+# rev = "<some commit hash>"
 
 # --snip--
 ```

--- a/docs/tutorials/creating-a-runtime-module.md
+++ b/docs/tutorials/creating-a-runtime-module.md
@@ -31,12 +31,11 @@ We'll begin from cloning the necessary repositories:
 
 ```bash
 cd my-playground-folder
-# cloning from a standard node template
+# clone from a standard node template
 git clone https://github.com/substrate-developer-hub/substrate-node-template.git my-node
-# cloning from a standard module template
+# clone from a standard module template
 git clone https://github.com/substrate-developer-hub/substrate-module-template.git my-module
-
-# kicking off the node compilation
+# kick off the node compilation
 cd my-node
 cargo build --release
 ```
@@ -282,7 +281,7 @@ your node runtime. Compile and run your node with:
 
 ```bash
 cd my-playground-folder/my-node
-# compiling your node
+# compile your node
 cargo build --release
 # purge any existing chain
 cargo run --release -- purge-chain --dev


### PR DESCRIPTION
@JoshOrndorff @shawntabrizi  Feel free to update/modify on top of this branch

Updates mostly consisted of:

- the 1st section `Create your Node` clone from substrate-node-template, instead of `substrate-new-node`
- module template clone from https://github.com/substrate-developer-hub/substrate-module-template, instead of Shawn personal github repo.
- some path update, and the adding description on path relationship between node-template and module-template, and which `Cargo.toml` we are talking about.
- Don't recommend the v1.0 branch
- Added a next step section at the end
