### PR TITLE
Fix capitalization on images

### DIFF
--- a/website/data/users.js
+++ b/website/data/users.js
@@ -387,7 +387,7 @@ const usersList = [{
   },
   {
     name: "Use Tech",
-    image: "/img/users/useTech.png",
+    image: "/img/users/UseTech.png",
     homepage: "https://www.usetech.com/",
     github: "https://github.com/usetech-llc",
     pinned: false,


### PR DESCRIPTION
Firefox fails to load some images because of capitalization issues with the image filename.

Does not fail on chrome.