### PR TITLE
Remove incorrect second title from Instantiable modules in v1.0 docs.

### DIFF
--- a/website/versioned_docs/version-1.0/runtime/instantiable-module.md
+++ b/website/versioned_docs/version-1.0/runtime/instantiable-module.md
@@ -4,12 +4,6 @@ id: version-1.0-instantiable-module
 original_id: instantiable-module
 ---
 
----
-title: Initializing Runtime Storage
-id: version-1.0-initializing-storage
-original_id: initializing-storage
----
-
 Unlike other runtime modules, instantiable modules enable multiple instances of the same module logic within a single runtime. Each instance of the module has its own independent storage, and extrinsics must specify which instance of the module they are intended for.
 
 Some use cases:


### PR DESCRIPTION
There was a weird second title section in the versioned instantiable module doc which caused it to render like this

![image](https://user-images.githubusercontent.com/2915325/68543738-85655600-03bb-11ea-94f3-f5e60c01d7f5.png)


I've simply removed it here.