### PR TITLE
Adding script and logic for deploying staging site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,10 +14,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            # This key added by @paritytech-ci
             - "a1:f6:36:72:14:54:c0:37:47:fe:0f:c1:01:7f:21:f5"
-            # Old key added by Joshy
-            #- "db:18:fc:b1:b6:20:68:47:61:df:13:d7:c6:24:12:1e"
       - checkout
       - run:
           name: Deploying to GitHub Pages

--- a/scripts/deploy-staging
+++ b/scripts/deploy-staging
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+# set -x
+set -e
+
+APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+GIT_REPO="https://github.com/jimmychu0807/substrate-devhub.git"
+PROJECT_BUILD_DIR="build/substrate-devhub"
+
+HTPASSWD='parity-devEx:$apr1$P.1bMHSB$u2PQ7KitD5aNk371vsQB0/'
+HTACCESS="AuthUserFile /app/.htpasswd\n
+AuthType Basic\n
+AuthName \"Restricted Access\"\n
+Require valid-user"
+
+# cmd for building
+echo $APP_DIR
+pushd $APP_DIR > /dev/null
+
+cd website
+rm -rf build
+
+yarn install && yarn write-translations
+
+# TODO: Add cmds for integrating translation
+
+NODE_ENV=staging GIT_REV=`git rev-parse --short HEAD` yarn build
+
+# push to heroku
+cd $PROJECT_BUILD_DIR
+
+git init .
+git remote add origin $GIT_REPO
+git checkout -b staging
+
+# Adding necessary files for using heroku php buildpack
+echo '<?php header("Location: /index.html");?>' > index.php
+echo $HTPASSWD > .htpasswd
+echo -e $HTACCESS > .htaccess
+
+# Everything done locally should be completed by this point. Merged back with upstream.
+git add .
+git commit -m "Updated"
+git push -f origin staging
+popd

--- a/scripts/deploy-staging
+++ b/scripts/deploy-staging
@@ -3,8 +3,8 @@
 set -e
 
 APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
-GIT_REPO="https://github.com/jimmychu0807/substrate-devhub.git"
-PROJECT_BUILD_DIR="build/substrate-devhub"
+GIT_REPO="https://github.com/substrate-developer-hub/substrate-developer-hub.github.io.git"
+PROJECT_BUILD_DIR="build/substrate-developer-hub.github.io"
 
 HTPASSWD='parity-devEx:$apr1$P.1bMHSB$u2PQ7KitD5aNk371vsQB0/'
 HTACCESS="AuthUserFile /app/.htpasswd\n

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -23,22 +23,33 @@ const users = require('./data/users');
 // List of videos on the "videos" page
 const videos = require('./data/videos');
 
+const is_staging = (process.env['NODE_ENV'] == 'staging');
+const git_rev = is_staging ? process.env['GIT_REV'] : null;
+const title_prefix = "Substrate Developer Hub";
+const title = is_staging ? `${title_prefix} (@${git_rev})` : title_prefix;
+const custom_url = 'substrate.dev';
+const cname = is_staging ? `staging.${custom_url}` : custom_url;
+
 const siteConfig = {
-  title: 'Substrate Developer Hub', // Title for your website.
+  title, // Title for your website.
   tagline: 'The place for blockchain innovators.',
 
-  url: 'https://substrate-developer-hub.github.io/', // Your website URL
-  baseUrl: '/', // Base URL for your project */
+  // Used for publishing and more
+  organizationName: 'substrate-developer-hub',
+  projectName: 'substrate-developer-hub.github.io',
+  // For top-level user or org sites, the organization is still the same.
+  // e.g., for the https://JoelMarcey.github.io site, it would be set like...
+  //   organizationName: 'JoelMarcey'
+
+  // Your website URL
+  url: 'https://substrate-developer-hub.github.io/',
+  baseUrl: "/", // Base URL for your project */
   // For github.io type URLs, you would set the url and baseUrl like:
   //   url: 'https://facebook.github.io',
   //   baseUrl: '/test-site/',
 
-  // Used for publishing and more
-  projectName: 'substrate-developer-hub.github.io',
-  organizationName: 'substrate-developer-hub',
-  // For top-level user or org sites, the organization is still the same.
-  // e.g., for the https://JoelMarcey.github.io site, it would be set like...
-  //   organizationName: 'JoelMarcey'
+  // Generate CNAME file when building
+  cname,
 
   // For no header links in the top nav bar -> headerLinks: [],
   headerLinks: [
@@ -132,9 +143,6 @@ const siteConfig = {
   stylesheets: [
     'https://stackpath.bootstrapcdn.com/bootstrap/4.3.1/css/bootstrap.min.css'
   ],
-
-  // Generate CNAME file when building
-  cname: 'substrate.dev',
 
   // Translation recruitment link, appears in the language drop down as "Help Translate"
   translationRecruitingLink:


### PR DESCRIPTION
Staging site deployed at: https://staging.substrate.dev

**Instruction to use**
- Work on your new doc / UI change in your branch. 
- Commit your new change. 
- Run `scripts/deploy-staging`. This generates published pages and push those pages to `staging` branch, which Heroku is configured to pickup and deploy to the site.
- When everything looks good, you can merge/PR your branch to `source`, and deploy to production of substrate doc site.

**Next todo**
- Integrate with translation
