### PR TITLE
Add sidebars for private network tutorial

### DIFF
--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -118,5 +118,14 @@
       "tutorials/creating-your-first-substrate-chain/build",
       "tutorials/creating-your-first-substrate-chain/front-end"
     ]
+  },
+  "start-a-private-network": {
+    "Start a Private Network": [
+      "tutorials/start-a-private-network/index",
+      "tutorials/start-a-private-network/compile",
+      "tutorials/start-a-private-network/alicebob",
+      "tutorials/start-a-private-network/keygen",
+      "tutorials/start-a-private-network/customchain"
+    ]
   }
 }


### PR DESCRIPTION
In my recent PR to update the private network tutorial, I failed to add the proper sidebars to the tutorial. This solves that.

We will also need to update the link on from the tutorials index when we launch v2.0