### PR TITLE
Create new Seminar playlist.

### DIFF
--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -226,7 +226,7 @@ function Community(props) {
         <Button
           variant="secondary"
           size="sm"
-          href="https://calendar.google.com/event?action=TEMPLATE&tmeid=ODFrdXNkNjczYTZwZzM1ZGg1c2RscHY2cG5fMjAxOTExMTlUMTQwMDAwWiBwYXJpdHkuaW9fMzkzNzkzNDNoMDczdjA2cWh0MXZwcWNlZmNAZw&tmsrc=parity.io_39379343h073v06qht1vpqcefc%40group.calendar.google.com&scp=ALL"
+          href="https://www.youtube.com/playlist?list=PLsBc7YjizKUwc3AcNb9oNZvtsN0QmAJPP"
           className="m-1 primary-color"
         >
           Google Calendar

--- a/website/pages/en/seminar.js
+++ b/website/pages/en/seminar.js
@@ -53,7 +53,7 @@ function Seminar(props) {
           },
           {
             key: 'key',
-            href: 'https://www.youtube.com/playlist?list=PLp0_ueXY_enUCPszf_3Q9ZxovLvKm1eMx',
+            href: 'https://www.youtube.com/playlist?list=PLsBc7YjizKUwc3AcNb9oNZvtsN0QmAJPP',
             name: 'Previous Recordings'
           },
       ]}
@@ -90,7 +90,7 @@ function Seminar(props) {
           Is this related to Substrate Collaborative Learning?
         </h3>
         <p>
-          Yes! Substrate Collaborative Learning was the previous harder-to-pronounce iteration of Substrate Seminar. When we decided to start meeting every week, and have a more discoverable web presence, we rebranded. If you liked Substrate Collaborative Learning, you'll <em>love</em> Substrate Seminar.
+          Yes! Substrate Collaborative Learning was the previous harder-to-pronounce iteration of Substrate Seminar. When we decided to start meeting every week, and have a more discoverable web presence, we rebranded. If you liked Substrate Collaborative Learning, you'll <em>love</em> Substrate Seminar. The <a href="https://www.youtube.com/playlist?list=PLp0_ueXY_enUCPszf_3Q9ZxovLvKm1eMx">SCL recordings</a> are still available.
         </p>
         <h3>
           To learn more visit <a href="https://www.parity.io/substrate/" target="_blank">parity.io/substrate</a>


### PR DESCRIPTION
This points links to the newly-created Substrate Seminar playlist while squirreling away a pointer to the old SCL playlist so it is still accessible. Both playlists link to each other on youtube.