### PR TITLE
Remove crates.parity.io links

### DIFF
--- a/docs/ecosystem/contracts/ink.md
+++ b/docs/ecosystem/contracts/ink.md
@@ -8,7 +8,7 @@ Because Substrate supports Wasm smart contracts, it means that any language that
 
 ## Contracts Module
 
-The SRML Contracts module provides the ability for the runtime to deploy and execute WebAssembly smart contracts. Here we will provide a short overview of the major features of the contracts module. To really learn all of the fine details, you can take a look at the [reference documentation for `srml_contracts`](https://crates.parity.io/srml_contracts/index.html).
+The SRML Contracts module provides the ability for the runtime to deploy and execute WebAssembly smart contracts. Here we will provide a short overview of the major features of the contracts module. To really learn all of the fine details, you can take a look at the [reference documentation for `srml_contracts`](https://substrate.dev/rustdocs/v1.0/srml_contract/index.html).
 
 ### Account Based
 

--- a/docs/overview/session-keys.md
+++ b/docs/overview/session-keys.md
@@ -25,6 +25,6 @@ The default Substrate node implements Session keys in the [Session module](https
 
 ## Generation and Use
 
-Session keys are hot keys that must be kept online. They are not meant to be used as account keys. If one of the Session keys is compromised, the attacker could commit slashable behavior. Session keys may be changed regularly (e.g. every session) via [RPC](https://crates.parity.io/substrate_rpc/author/trait.AuthorApi.html#tymethod.rotate_keys) for increased security.
+Session keys are hot keys that must be kept online. They are not meant to be used as account keys. If one of the Session keys is compromised, the attacker could commit slashable behavior. Session keys may be changed regularly (e.g. every session) via [RPC](https://substrate.dev/rustdocs/v1.0/substrate_rpc/author/trait.AuthorApi.html#tymethod.rotate_keys) for increased security.
 
 <!--Note: RPC link is to master and may break. v1.0 docs do not have the requisite endpoints.-->

--- a/docs/runtime/macros/construct_runtime.md
+++ b/docs/runtime/macros/construct_runtime.md
@@ -140,7 +140,7 @@ decl_storage! {
 }
 ```
 
-You can learn more about [`decl_storage!`](https://crates.parity.io/srml_support_procedural/macro.decl_storage.html)
+You can learn more about [`decl_storage!`](https://substrate.dev/rustdocs/v1.0/srml_support_procedural/macro.decl_storage.html)
 
 ### Event
 

--- a/docs/runtime/substrate-runtime-module-library.md
+++ b/docs/runtime/substrate-runtime-module-library.md
@@ -39,7 +39,7 @@ You can build your own custom module by deriving from the system module (describ
 
 The following are the modules that ship with the SRML.
 
-* [Assets](https://crates.parity.io/srml_assets/index.html)
+* [Assets](https://substrate.dev/rustdocs/v1.0/srml_assets/index.html)
 * [Aura](https://substrate.dev/rustdocs/v1.0/srml_aura/index.html)
 * [Balances](https://substrate.dev/rustdocs/v1.0/srml_balances/index.html)
 * [Consensus](https://substrate.dev/rustdocs/v1.0/srml_consensus/index.html)

--- a/docs/tutorials/adding-a-module-to-your-runtime.md
+++ b/docs/tutorials/adding-a-module-to-your-runtime.md
@@ -358,4 +358,4 @@ In the `Cargo.toml` file of the Substrate node runtime, you will see an example 
 
 ### References
 
-- [SRML `Contracts` module API](https://crates.parity.io/srml_contracts/index.html)
+- [SRML `Contracts` module API](https://substrate.dev/rustdocs/master/pallet_contracts/index.html)

--- a/website/versioned_docs/version-1.0/ecosystem/contracts/ink.md
+++ b/website/versioned_docs/version-1.0/ecosystem/contracts/ink.md
@@ -10,7 +10,7 @@ Because Substrate supports Wasm smart contracts, it means that any language that
 
 ## Contracts Module
 
-The SRML Contracts module provides the ability for the runtime to deploy and execute WebAssembly smart contracts. Here we will provide a short overview of the major features of the contracts module. To really learn all of the fine details, you can take a look at the [reference documentation for `srml_contracts`](https://crates.parity.io/srml_contracts/index.html).
+The SRML Contracts module provides the ability for the runtime to deploy and execute WebAssembly smart contracts. Here we will provide a short overview of the major features of the contracts module. To really learn all of the fine details, you can take a look at the [reference documentation for `srml_contracts`](https://substrate.dev/rustdocs/v1.0/srml_contract/index.html).
 
 ### Account Based
 

--- a/website/versioned_docs/version-1.0/overview/session-keys.md
+++ b/website/versioned_docs/version-1.0/overview/session-keys.md
@@ -27,6 +27,6 @@ The default Substrate node implements Session keys in the [Session module](https
 
 ## Generation and Use
 
-Session keys are hot keys that must be kept online. They are not meant to be used as account keys. If one of the Session keys is compromised, the attacker could commit slashable behavior. Session keys may be changed regularly (e.g. every session) via [RPC](https://crates.parity.io/substrate_rpc/author/trait.AuthorApi.html#tymethod.rotate_keys) for increased security.
+Session keys are hot keys that must be kept online. They are not meant to be used as account keys. If one of the Session keys is compromised, the attacker could commit slashable behavior. Session keys may be changed regularly (e.g. every session) via [RPC](https://substrate.dev/rustdocs/v1.0/substrate_rpc/author/trait.AuthorApi.html#tymethod.rotate_keys) for increased security.
 
 <!--Note: RPC link is to master and may break. v1.0 docs do not have the requisite endpoints.-->

--- a/website/versioned_docs/version-1.0/runtime/macros/construct_runtime.md
+++ b/website/versioned_docs/version-1.0/runtime/macros/construct_runtime.md
@@ -142,7 +142,7 @@ decl_storage! {
 }
 ```
 
-You can learn more about [`decl_storage!`](https://crates.parity.io/srml_support_procedural/macro.decl_storage.html)
+You can learn more about [`decl_storage!`](https://substrate.dev/rustdocs/v1.0/srml_support_procedural/macro.decl_storage.html)
 
 ### Event
 

--- a/website/versioned_docs/version-1.0/runtime/substrate-runtime-module-library.md
+++ b/website/versioned_docs/version-1.0/runtime/substrate-runtime-module-library.md
@@ -41,7 +41,7 @@ You can build your own custom module by deriving from the system module (describ
 
 The following are the modules that ship with the SRML.
 
-* [Assets](https://crates.parity.io/srml_assets/index.html)
+* [Assets](https://substrate.dev/rustdocs/v1.0/srml_assets/index.html)
 * [Aura](https://substrate.dev/rustdocs/v1.0/srml_aura/index.html)
 * [Balances](https://substrate.dev/rustdocs/v1.0/srml_balances/index.html)
 * [Consensus](https://substrate.dev/rustdocs/v1.0/srml_consensus/index.html)

--- a/website/versioned_docs/version-1.0/tutorials/adding-a-module-to-your-runtime.md
+++ b/website/versioned_docs/version-1.0/tutorials/adding-a-module-to-your-runtime.md
@@ -237,7 +237,7 @@ Now, when the Balances module detects that the free balance of an account has re
 
 ## Genesis Configuration
 
-The last thing we need to do in order to get your node up and running is to establish a genesis configuration for the Contract module. Not all modules will have a genesis configuration, but if they do, you can use its documentation to learn about it. For example, [`srml_contracts::GenesisConfig` documentation](https://substrate.dev/rustdocs/v1.0/srml_contracts/struct.GenesisConfig.html) describes all the fields you need to define for the Contract module. This definition is controlled in `contract-chain/src/chain_spec.rs`. We need to modify this file to include the `ContractConfig` type:
+The last thing we need to do in order to get your node up and running is to establish a genesis configuration for the Contract module. Not all modules will have a genesis configuration, but if they do, you can use its documentation to learn about it. For example, [`srml_contracts::GenesisConfig` documentation](https://substrate.dev/rustdocs/v1.0/srml_contract/struct.GenesisConfig.html) describes all the fields you need to define for the Contract module. This definition is controlled in `contract-chain/src/chain_spec.rs`. We need to modify this file to include the `ContractConfig` type:
 
 ```rust
 use contract_chain_runtime::ContractConfig;

--- a/website/versioned_docs/version-1.0/tutorials/creating-your-first-substrate-chain.md
+++ b/website/versioned_docs/version-1.0/tutorials/creating-your-first-substrate-chain.md
@@ -102,7 +102,7 @@ pub trait Trait: balances::Trait {}
 
 In this example, we will create a simple coin flip game. Users will pay an entry fee to play the game and then "flip a coin". If they win they will get the contents of the pot. If they don't win, they will get nothing. No matter the outcome, their fee will be placed into the pot after the game resolves for the next user to try and win.
 
-To start, we can define the storage items our module needs to track with the [`decl_storage!` macro](https://crates.parity.io/srml_support_procedural/macro.decl_storage.html):
+To start, we can define the storage items our module needs to track with the [`decl_storage!` macro](https://substrate.dev/rustdocs/v1.0/srml_support_procedural/macro.decl_storage.html):
 
 ```rust
 decl_storage! {


### PR DESCRIPTION
Most of them convert to `rustdocs/v1.0`, one case, I changed to `rustdocs/master/pallet_`