### PR TITLE
Remove duplicated git dependency in install command

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -22,7 +22,7 @@ To develop in the Substrate ecosystem, you must set up your developer environmen
 Run:
 
 ```bash
-sudo apt install -y cmake pkg-config libssl-dev git gcc build-essential git clang libclang-dev
+sudo apt install -y cmake pkg-config libssl-dev git gcc build-essential clang libclang-dev
 ```
 
 ### macOS


### PR DESCRIPTION
The prerequisite install command (for Debian) had `git` listed twice. While harmless, it was confusing and not idiomatic. This removes the second occurrence.