### PR TITLE
Fix consensus images

### DIFF
--- a/docs/conceptual/core/consensus.md
+++ b/docs/conceptual/core/consensus.md
@@ -63,7 +63,8 @@ this chain selection rule with the
 the longest chain rule for voting.
 
 <!--TODO: Get Zsofia to make nice graphic -->
-![longest chain rule](../../assets/consensus-longest-chain.png)
+
+![longest chain rule](assets/consensus-longest-chain.png)
 
 ### GHOST Rule
 
@@ -71,7 +72,8 @@ The Greedy Heaviest Observed SubTree rule says that, starting at the genesis blo
 resolved by choosing the branch that has the most blocks built on it recursively.
 
 <!--TODO: Get Zsofia to make nice graphic -->
-![GHOST rule](../../assets/consensus-ghost.png)
+
+![GHOST rule](assets/consensus-ghost.png)
 
 ## Block Production
 


### PR DESCRIPTION
The images in the consensus writeup were not showing because there needs to be a blank line before images in markdown.