### PR TITLE
Table of Contents: Remove Conceptual and Developer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,10 +56,8 @@ Substrate documentation is split into three projects:
 
 * Substrate Recipes - `substrate.dev/recipes/`
 
-   General best practice guidelines on how to develop with Substrate.
-   If you create best practice documentation about using a specific
-   feature of Substrate, you should create the documentation in the same
-   directory as the other documentation for that specific feature. See the [contribution guidelines](https://github.com/substrate-developer-hub/recipes/blob/master/CONTRIBUTING.md) for more details.
+   Examples and best practice guidelines on how to develop with Substrate, complete with working
+   code. If you create an example of using a specific Substrate feature, it belongs in the recipes.
 
 * Substrate Rust Documentation - `substrate.dev/rustdocs/`
 
@@ -67,24 +65,13 @@ Substrate documentation is split into three projects:
 
 * Substrate Developer Documentation - `substrate.dev/docs/`
 
-   In the `/docs/` directory, you should create your
-   documentation or images in one of these sub-directories:
-    
-   *  `development`
-        Instructions, tutorials, and procedural documentation for developers
-        who are working on Substrate. This directory includes documentation
-        on how to get started, build, run, and test Substrate. You should organize the content
-        that you create by specific activities, such as testing, getting
-        started, or by workflow topic.
-    
-   * `conceptual`
-        Concept and developer guides about the features of Substrate. You
-        should organize the content that you create by specific features.
-    
-   * `images`
-        Images that are used in the documentation. You should place images in
-        this common directory and avoid placing images in the same directory
-        as documentation.
+  Instructions, conceptual overviews, and procedural documentation for developers who are working
+  on Substrate. This directory includes documentation on how to get started, build, run, and test
+  Substrate. You should organize the content that you create by specific activities, such as
+  testing, getting started, or by workflow topic.
+
+  Images that are used in the documentation belong in the common `assets` directory. Avoid placing
+  images in the same directory as documentation.
 
 ### What documentation should I create?
 

--- a/docs/conceptual/index.md
+++ b/docs/conceptual/index.md
@@ -1,5 +1,0 @@
----
-title: Conceptual Documentation
----
-
-This document is a top-level entry point to the conceptual documentation for Substrate.

--- a/docs/conceptual/runtime/contracts/ink.md
+++ b/docs/conceptual/runtime/contracts/ink.md
@@ -1,5 +1,5 @@
 ---
-title: ink!
+title: ink! Concepts
 ---
 
 ink! is a [Rust](https://www.rust-lang.org/)-based embedded domain specific language

--- a/docs/development/contracts/ink.md
+++ b/docs/development/contracts/ink.md
@@ -1,5 +1,5 @@
 ---
-title: ink!
+title: ink! Development
 ---
 
 ink! is a [Rust](https://www.rust-lang.org/)-based embedded domain specific language

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -1,5 +1,0 @@
----
-title: Developer Documentation
----
-
-This document is a top-level entry point to developer documentation related to developing on Substrate.

--- a/website/sidebars-full.json
+++ b/website/sidebars-full.json
@@ -1,123 +1,70 @@
 {
   "docs": {
-    "Overview": ["index", "getting-started", "glossary"],
-    "Conceptual": [
-      "conceptual/index",
-      {
-        "type": "subcategory",
-        "label": "Substrate Core",
-        "ids": [
-          "conceptual/core/codec",
-          "conceptual/core/consensus",
-          "conceptual/core/executor",
-          "conceptual/core/networking",
-          "conceptual/core/off-chain-workers",
-          "conceptual/core/storage"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Substrate Nodes",
-        "ids": [
-          "conceptual/node/client",
-          "conceptual/node/light-client",
-          "conceptual/node/extrinsics",
-          "conceptual/node/rpc",
-          "conceptual/node/tx-pool"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Cryptography",
-        "ids": [
-          "conceptual/cryptography/index",
-          "conceptual/cryptography/keys",
-          "conceptual/cryptography/session-keys",
-          "conceptual/cryptography/ss58-address-format"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Substrate Runtime",
-        "ids": [
-          "conceptual/runtime/index",
-          "conceptual/runtime/frame",
-          "conceptual/runtime/weight",
-          "conceptual/runtime/primitives"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Smart Contracts",
-        "ids": [
-          "conceptual/runtime/contracts/index",
-          "conceptual/runtime/contracts/contracts_module",
-          "conceptual/runtime/contracts/evm_module",
-          "conceptual/runtime/contracts/ink"
-        ]
-      }
+    "Overview": [
+      "index",
+      "getting-started",
+      "conceptual/runtime/frame",
+      "glossary"
+    ],
+    "Substrate Core": [
+      "conceptual/core/codec",
+      "conceptual/core/consensus",
+      "conceptual/core/executor",
+      "conceptual/core/networking",
+      "conceptual/core/off-chain-workers",
+      "conceptual/core/storage"
+    ],
+    "Substrate Nodes": [
+      "conceptual/node/client",
+      "conceptual/node/light-client",
+      "conceptual/node/extrinsics",
+      "conceptual/node/rpc",
+      "conceptual/node/tx-pool"
+    ],
+    "Cryptography": [
+      "conceptual/cryptography/index",
+      "conceptual/cryptography/keys",
+      "conceptual/cryptography/session-keys",
+      "conceptual/cryptography/ss58-address-format"
+    ],
+    "Substrate Runtime": [
+      "conceptual/runtime/index",
+      "conceptual/runtime/weight",
+      "conceptual/runtime/primitives",
+      "development/module/execution",
+      "development/module/macros",
+      "development/module/origin",
+      "development/module/declaration",
+      "development/module/storage",
+      "development/module/events",
+      "development/module/errors",
+      "development/module/traits",
+      "development/module/off-chain-workers",
+      "development/module/fees",
+      "development/module/tests"
+    ],
+    "Smart Contracts": [
+      "conceptual/runtime/contracts/index",
+      "conceptual/runtime/contracts/contracts_module",
+      "conceptual/runtime/contracts/evm_module",
+      "conceptual/runtime/contracts/ink",
+      "development/contracts/ink"
     ],
     "Development": [
-      "development/index",
-      {
-        "type": "subcategory",
-        "label": "Build",
-        "ids": [
-          "development/build/prerequisites",
-          "development/build/purge-chain",
-          "development/build/upgrade"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Runtime Modules",
-        "ids": [
-          "development/module/index",
-          "development/module/execution",
-          "development/module/macros",
-          "development/module/origin",
-          "development/module/declaration",
-          "development/module/storage",
-          "development/module/events",
-          "development/module/errors",
-          "development/module/traits",
-          "development/module/off-chain-workers",
-          "development/module/fees",
-          "development/module/tests"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Deployment",
-        "ids": [
-          "development/deployment/chain-spec",
-          "development/deployment/account-prefix",
-          "development/deployment/boot-node",
-          "development/deployment/disabling-features"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Front End",
-        "ids": [
-          "development/front-end/polkadot-js",
-          "development/front-end/json-rpc"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Smart Contracts",
-        "ids": [
-          "development/contracts/ink"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Ecosystem Tools",
-        "ids": [
-          "development/tools/subkey"
-        ]
-      }
+      "development/build/prerequisites",
+      "development/build/purge-chain",
+      "development/build/upgrade",
+      "development/deployment/chain-spec",
+      "development/deployment/account-prefix",
+      "development/deployment/boot-node",
+      "development/deployment/disabling-features"
+    ],
+    "Front End": [
+      "development/front-end/polkadot-js",
+      "development/front-end/json-rpc"
+    ],
+    "Ecosystem Tools": [
+      "development/tools/subkey"
     ]
   },
   "creating-your-first-substrate-chain": {

--- a/website/sidebars-with-hidden.json
+++ b/website/sidebars-with-hidden.json
@@ -1,109 +1,61 @@
 {
   "docs": {
-    "Overview": ["index", "getting-started", "glossary"],
-    "Conceptual": [
-      {
-        "type": "subcategory",
-        "label": "Substrate Core",
-        "ids": [
-          "conceptual/core/codec",
-          "conceptual/core/consensus",
-          "conceptual/core/executor",
-          "conceptual/core/off-chain-workers",
-          "conceptual/core/storage"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Substrate Nodes",
-        "ids": [
-          "conceptual/node/extrinsics"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Cryptography",
-        "ids": [
-          "conceptual/cryptography/index",
-          "conceptual/cryptography/keys",
-          "conceptual/cryptography/session-keys",
-          "conceptual/cryptography/ss58-address-format"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Substrate Runtime",
-        "ids": [
-          "conceptual/runtime/frame",
-          "conceptual/runtime/weight",
-          "conceptual/runtime/primitives"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Smart Contracts",
-        "ids": [
-          "conceptual/runtime/contracts/index",
-          "conceptual/runtime/contracts/contracts_module",
-          "conceptual/runtime/contracts/evm_module",
-          "conceptual/runtime/contracts/ink"
-        ]
-      }
-    ],
-    "Development": [
-      {
-        "type": "subcategory",
-        "label": "Build",
-        "ids": [
-          "development/build/prerequisites",
-          "development/build/purge-chain",
-          "development/build/upgrade"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Runtime Modules",
-        "ids": [
-          "development/module/index",
-          "development/module/execution",
-          "development/module/macros",
-          "development/module/origin",
-          "development/module/storage",
-          "development/module/events",
-          "development/module/off-chain-workers",
-          "development/module/fees",
-          "development/module/tests"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Deployment",
-        "ids": [
-          "development/deployment/chain-spec"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Front End",
-        "ids": [
-          "development/front-end/polkadot-js"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Smart Contracts",
-        "ids": [
-          "development/contracts/ink"
-        ]
-      },
-      {
-        "type": "subcategory",
-        "label": "Ecosystem Tools",
-        "ids": [
-          "development/tools/subkey"
-        ]
-      }
-    ]
+  	"Overview": [
+  		"index",
+  		"getting-started",
+  		"conceptual/runtime/frame",
+  		"glossary"
+  	],
+  	"Substrate Core": [
+  		"conceptual/core/codec",
+  		"conceptual/core/consensus",
+  		"conceptual/core/executor",
+  		"conceptual/core/off-chain-workers",
+  		"conceptual/core/storage"
+  	],
+  	"Substrate Nodes": [
+  		"conceptual/node/extrinsics"
+  	],
+  	"Cryptography": [
+  		"conceptual/cryptography/index",
+  		"conceptual/cryptography/keys",
+  		"conceptual/cryptography/session-keys",
+  		"conceptual/cryptography/ss58-address-format"
+  	],
+  	"Substrate Runtime": [
+  		"conceptual/runtime/weight",
+  		"conceptual/runtime/primitives",
+  		"development/module/execution",
+  		"development/module/macros",
+  		"development/module/storage",
+  		"development/module/events",
+  		"development/module/off-chain-workers",
+  		"development/module/fees",
+  		"development/module/tests"
+  	],
+  	"Smart Contracts": [
+  		"conceptual/runtime/contracts/index",
+  		"conceptual/runtime/contracts/contracts_module",
+  		"conceptual/runtime/contracts/evm_module",
+  		"conceptual/runtime/contracts/ink",
+  		"development/contracts/ink"
+  	],
+  	"Deployment": [
+  		"development/build/prerequisites",
+  		"development/build/purge-chain",
+  		"development/build/upgrade",
+  		"development/deployment/chain-spec",
+  		"development/deployment/account-prefix",
+  		"development/deployment/boot-node",
+  		"development/deployment/disabling-features"
+  	],
+  	"Front End": [
+  		"development/front-end/polkadot-js",
+  		"development/front-end/json-rpc"
+  	],
+  	"Ecosystem Tools": [
+  		"development/tools/subkey"
+  	]
   },
   "creating-your-first-substrate-chain": {
     "Creating Your First Substrate Chain": [

--- a/website/sidebars-with-hidden.json
+++ b/website/sidebars-with-hidden.json
@@ -1,61 +1,61 @@
 {
   "docs": {
-  	"Overview": [
-  		"index",
-  		"getting-started",
-  		"conceptual/runtime/frame",
-  		"glossary"
-  	],
-  	"Substrate Core": [
-  		"conceptual/core/codec",
-  		"conceptual/core/consensus",
-  		"conceptual/core/executor",
-  		"conceptual/core/off-chain-workers",
-  		"conceptual/core/storage"
-  	],
-  	"Substrate Nodes": [
-  		"conceptual/node/extrinsics"
-  	],
-  	"Cryptography": [
-  		"conceptual/cryptography/index",
-  		"conceptual/cryptography/keys",
-  		"conceptual/cryptography/session-keys",
-  		"conceptual/cryptography/ss58-address-format"
-  	],
-  	"Substrate Runtime": [
-  		"conceptual/runtime/weight",
-  		"conceptual/runtime/primitives",
-  		"development/module/execution",
-  		"development/module/macros",
-  		"development/module/storage",
-  		"development/module/events",
-  		"development/module/off-chain-workers",
-  		"development/module/fees",
-  		"development/module/tests"
-  	],
-  	"Smart Contracts": [
-  		"conceptual/runtime/contracts/index",
-  		"conceptual/runtime/contracts/contracts_module",
-  		"conceptual/runtime/contracts/evm_module",
-  		"conceptual/runtime/contracts/ink",
-  		"development/contracts/ink"
-  	],
-  	"Deployment": [
-  		"development/build/prerequisites",
-  		"development/build/purge-chain",
-  		"development/build/upgrade",
-  		"development/deployment/chain-spec",
-  		"development/deployment/account-prefix",
-  		"development/deployment/boot-node",
-  		"development/deployment/disabling-features"
-  	],
-  	"Front End": [
-  		"development/front-end/polkadot-js",
-  		"development/front-end/json-rpc"
-  	],
-  	"Ecosystem Tools": [
-  		"development/tools/subkey"
-  	]
+    "Overview": [
+      "index",
+      "getting-started",
+      "conceptual/runtime/frame",
+      "glossary"
+    ],
+    "Substrate Core": [
+      "conceptual/core/codec",
+      "conceptual/core/consensus",
+      "conceptual/core/executor",
+      "conceptual/core/off-chain-workers",
+      "conceptual/core/storage"
+    ],
+    "Substrate Nodes": [
+      "conceptual/node/extrinsics"
+    ],
+    "Cryptography": [
+      "conceptual/cryptography/index",
+      "conceptual/cryptography/keys",
+      "conceptual/cryptography/session-keys",
+      "conceptual/cryptography/ss58-address-format"
+    ],
+    "Substrate Runtime": [
+      "conceptual/runtime/weight",
+      "conceptual/runtime/primitives",
+      "development/module/execution",
+      "development/module/macros",
+      "development/module/storage",
+      "development/module/events",
+      "development/module/off-chain-workers",
+      "development/module/fees",
+      "development/module/tests"
+    ],
+    "Smart Contracts": [
+      "conceptual/runtime/contracts/index",
+      "conceptual/runtime/contracts/contracts_module",
+      "conceptual/runtime/contracts/evm_module",
+      "conceptual/runtime/contracts/ink",
+      "development/contracts/ink"
+    ],
+    "Deployment": [
+      "development/build/prerequisites",
+      "development/build/purge-chain",
+      "development/build/upgrade",
+      "development/deployment/chain-spec",
+      "development/deployment/account-prefix",
+      "development/deployment/boot-node",
+      "development/deployment/disabling-features"
+    ],
+    "Front End": [
+      "development/front-end/polkadot-js",
+      "development/front-end/json-rpc"
+    ],
+    "Ecosystem Tools": [
+      "development/tools/subkey"
+    ]
   },
   "creating-your-first-substrate-chain": {
     "Creating Your First Substrate Chain": [


### PR DESCRIPTION
This PR removes the distinction between Developer and Conceptual documentation as we discussed in the team meeting on 6 Jan.

While the table of contents is correctly updated, the file structure is not changed. I propose that we don't change the underlying file structure until we decide that we can abandon the v1.0 docs entirely. Because of a [bug in docusaurus](https://github.com/facebook/docusaurus/issues/845), files that existed in any previous version must still exist in the current version. Once we decide we can abandon the v1.0 docs, we can then clean up the file structure and cut a new version.