### PR TITLE
Fix links from docusaurus to recipes

### DIFF
--- a/docs/conceptual/runtime/weight.md
+++ b/docs/conceptual/runtime/weight.md
@@ -57,7 +57,7 @@ operational class.
 ### Learn More
 
 - Substrate Recipes contains examples of both [custom
-  weights](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/modules/weights)
+  weights](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/pallets/weights)
   and custom
   [WeightToFee](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes/weight-fee-runtime).
 - The [srml-example](https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs)
@@ -66,7 +66,7 @@ operational class.
 ### Examples
 
 - See an example of [adding a transaction
-  weight](https://substrate.dev/recipes/design/econsecurity.html?highlight=weight#assigning-transaction-weights)
+  weight](https://substrate.dev/recipes/traits/fees.html#assigning-transaction-weights)
   to a custom runtime function.
 
 ### References

--- a/docs/development/module/events.md
+++ b/docs/development/module/events.md
@@ -107,9 +107,9 @@ The Substrate [JSON RPC](development/front-end/json-rpc.md) does not directly ex
 
 View the following Substrate [recipes](https://github.com/substrate-developer-hub/recipes) to find examples of how runtime events are used:
 
-* [A pallet which implements standard events]( https://github.com/substrate-developer-hub/recipes/blob/master/kitchen/modules/last-caller/src/lib.rs)
+* [A pallet which implements standard events]( https://github.com/substrate-developer-hub/recipes/blob/master/kitchen/pallets/last-caller/src/lib.rs)
 
-* [A pallet which does not emit events with generic types](https://github.com/substrate-developer-hub/recipes/blob/master/kitchen/adder/src/lib.rs)
+* [A pallet which does not emit events with generic types](https://github.com/substrate-developer-hub/recipes/blob/master/kitchen/pallets/adding-machine/src/lib.rs)
 
 ### References
 

--- a/docs/development/module/tests.md
+++ b/docs/development/module/tests.md
@@ -60,7 +60,14 @@ fn fake_test_example() {
 }
 ```
 
-Custom implementations of [Externalities](https://crates.parity.io/substrate_externalities/index.html) allow developers to construct runtime environments that provide access to features of the outer node. Another example of this can be found in [`substrate-offchain`](https://crates.parity.io/substrate_offchain/), which maintains its own [Externalities](https://crates.parity.io/substrate_offchain/testing/index.html) implementation. [Implementing configurable externalities](https://substrate.dev/recipes/testing/externalities.html) is covered in more depth in the recipes.
+Custom implementations of
+[Externalities](https://crates.parity.io/substrate_externalities/index.html) allow developers to
+construct runtime environments that provide access to features of the outer node. Another example of
+this can be found in [`substrate-offchain`](https://crates.parity.io/substrate_offchain/), which
+maintains its own [Externalities](https://crates.parity.io/substrate_offchain/testing/index.html)
+implementation. [Implementing configurable
+externalities](https://substrate.dev/recipes/testing/externalities.html) is covered in more depth in
+the recipes.
 
 #### Genesis Config
 

--- a/docs/development/module/tests.md
+++ b/docs/development/module/tests.md
@@ -60,7 +60,7 @@ fn fake_test_example() {
 }
 ```
 
-Custom implementations of [Externalities](https://crates.parity.io/substrate_externalities/index.html) allow developers to construct runtime environments that provide access to features of the outer node. Another example of this can be found in [`substrate-offchain`](https://crates.parity.io/substrate_offchain/), which maintains its own [Externalities](https://crates.parity.io/substrate_offchain/testing/index.html) implementation. [Implementing configurable externalities](https://substrate.dev/recipes/testing/externalities.htm) is covered in more depth in the recipes.
+Custom implementations of [Externalities](https://crates.parity.io/substrate_externalities/index.html) allow developers to construct runtime environments that provide access to features of the outer node. Another example of this can be found in [`substrate-offchain`](https://crates.parity.io/substrate_offchain/), which maintains its own [Externalities](https://crates.parity.io/substrate_offchain/testing/index.html) implementation. [Implementing configurable externalities](https://substrate.dev/recipes/testing/externalities.html) is covered in more depth in the recipes.
 
 #### Genesis Config
 


### PR DESCRIPTION
This PR fixes broken links from the devhub to the recipes.

I've also fixed broken links _from_ the recipes in https://github.com/substrate-developer-hub/recipes/pull/126

@jimmychu0807 pointed out the excellent drlinkchecher.com tool for finding broken links.