### PR TITLE
Add dev phrase to glossary

### DIFF
--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -92,6 +92,9 @@ The council is one of the SRML governance primitives and is a body of delegates 
 ## Database Backend
 The means by which data relating to the blockchain is persisted between invocations of the node.
 
+## Dev Phrase
+A Mnemonic phrase which is intentionally made public. All of the well-known development accounts (Alice, Bob, Charlie, Dave, Ferdie, and Eve) are generated from the same dev phrase. The dev phrase is: `bottom drive obey lake curtain smoke basket hold race lonely fit walk`
+
 ## Digest
 An extensible field of the block header that encodes information needed by header-only ("light") clients for chain synchronisation.
 
@@ -130,6 +133,8 @@ Within the SRML Balances module, this is the minimum balance an account may have
 > If the amount transferred is less than the existential deposit and the destination account did not previously exist, then the transfer will "succeed" without actually creating and crediting the destination account; this appears to essentially just burn the transfer balance from the sender. If the transfer takes the sender to below the existential balance, then its account will be deleted. In this way, a transfer can even "successfully" result in the sender account being completely deleted, with the receiver account never being created.
 >
 > It is up to middleware to ensure that end-users are made aware of and/or protected from these edge cases.
+
+---
 
 ## Finality
 A part of consensus dealing with making a progression be irreversible. If a block is finalised, then any real-world repercussions can be effected. The consensus algorithm must guarantee that finalised blocks never need reverting.

--- a/docs/overview/glossary.md
+++ b/docs/overview/glossary.md
@@ -93,7 +93,9 @@ The council is one of the SRML governance primitives and is a body of delegates 
 The means by which data relating to the blockchain is persisted between invocations of the node.
 
 ## Dev Phrase
-A Mnemonic phrase which is intentionally made public. All of the well-known development accounts (Alice, Bob, Charlie, Dave, Ferdie, and Eve) are generated from the same dev phrase. The dev phrase is: `bottom drive obey lake curtain smoke basket hold race lonely fit walk`
+A Mnemonic phrase which is intentionally made public. All of the well-known development accounts (Alice, Bob, Charlie, Dave, Ferdie, and Eve) are generated from the same dev phrase. The dev phrase is: `bottom drive obey lake curtain smoke basket hold race lonely fit walk`.
+
+Many tools in the Substrate ecosystem, such as subkey, allow users to implicitly specify the dev phrase with by only specifying a derivation path such as `//Alice`.
 
 ## Digest
 An extensible field of the block header that encodes information needed by header-only ("light") clients for chain synchronisation.


### PR DESCRIPTION
I find myself frequently describing the dev phrase and linking [directly to source](https://github.com/paritytech/substrate/blob/6e0a4877afbe2309e106b84333bb70200531b604/primitives/core/src/crypto.rs#L43). This PR adds a `Dev Phrase` item to the glossary says a sentence about what it is, and then lists the phrase. This will be a discoverable, linkable, and persistent place to document the dev phrase.