### PR TITLE
Companion PR for Recipes restructure

### DIFF
--- a/docs/conceptual/runtime/weight.md
+++ b/docs/conceptual/runtime/weight.md
@@ -57,9 +57,9 @@ operational class.
 ### Learn More
 
 - Substrate Recipes contains examples of both [custom
-  weights](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/pallets/weights)
+  weights](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/weights)
   and custom
-  [WeightToFee](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes/weight-fee-runtime).
+  [WeightToFee](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime).
 - The [srml-example](https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs)
   pallet.
 

--- a/docs/development/module/events.md
+++ b/docs/development/module/events.md
@@ -105,11 +105,11 @@ The Substrate [JSON RPC](development/front-end/json-rpc.md) does not directly ex
 
 ### Examples
 
-View the following Substrate [recipes](https://github.com/substrate-developer-hub/recipes) to find examples of how runtime events are used:
+These [Substrate Recipes](https://github.com/substrate-developer-hub/recipes) offer examples of how runtime events are used:
 
-* [A pallet which implements standard events]( https://github.com/substrate-developer-hub/recipes/blob/master/kitchen/pallets/last-caller/src/lib.rs)
+* [A pallet that implements standard events]( https://github.com/substrate-developer-hub/recipes/blob/master/pallets/last-caller/src/lib.rs)
 
-* [A pallet which does not emit events with generic types](https://github.com/substrate-developer-hub/recipes/blob/master/kitchen/pallets/adding-machine/src/lib.rs)
+* [A pallet that does not emit events with generic types](https://github.com/substrate-developer-hub/recipes/blob/master/pallets/adding-machine/src/lib.rs)
 
 ### References
 

--- a/docs/development/module/fees.md
+++ b/docs/development/module/fees.md
@@ -284,9 +284,9 @@ payment module drawing inspiration from Transaction Payment.
 ### Examples
 
 Substrate Recipes contains examples of both [custom
-weights](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/pallets/weights) and
+weights](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/weights) and
 custom
-[WeightToFee](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes/weight-fee-runtime).
+[WeightToFee](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime).
 
 ### References
 

--- a/docs/development/module/tests.md
+++ b/docs/development/module/tests.md
@@ -132,4 +132,4 @@ fn my_runtime_test() {
 
 ## Next Steps
 
-The [testing](https://substrate.dev/recipes/testing/index.html) chapter of the [Substrate Recipes](https://github.com/substrate-developer-hub/recipes/) compliments the samples shown above, and the [kitchen](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen) provides an environment to run the tests, change the logic, and tinker with the code.
+The [testing chapter](https://substrate.dev/recipes/testing/index.html) of the Substrate Recipes compliments the samples shown above, and provides an environment to run the tests, change the logic, and tinker with the code.

--- a/website/versioned_docs/version-pre-2.0/conceptual/runtime/weight.md
+++ b/website/versioned_docs/version-pre-2.0/conceptual/runtime/weight.md
@@ -57,9 +57,9 @@ operational class.
 ### Learn More
 
 - Substrate Recipes contains examples of both [custom
-  weights](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/pallets/weights)
+  weights](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/weights)
   and custom
-  [WeightToFee](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes/weight-fee-runtime).
+  [WeightToFee](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime).
 - The [srml-example](https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs)
   pallet.
 

--- a/website/versioned_docs/version-pre-2.0/development/module/events.md
+++ b/website/versioned_docs/version-pre-2.0/development/module/events.md
@@ -109,9 +109,9 @@ The Substrate [JSON RPC](development/front-end/json-rpc.md) does not directly ex
 
 View the following Substrate [recipes](https://github.com/substrate-developer-hub/recipes) to find examples of how runtime events are used:
 
-* [A pallet which implements standard events]( https://github.com/substrate-developer-hub/recipes/blob/master/kitchen/modules/last-caller/src/lib.rs)
+* [A pallet that implements standard events]( https://github.com/substrate-developer-hub/recipes/blob/master/modules/last-caller/src/lib.rs)
 
-* [A pallet which does not emit events with generic types](https://github.com/substrate-developer-hub/recipes/blob/master/kitchen/adder/src/lib.rs)
+* [A pallet that does not emit events with generic types](https://github.com/substrate-developer-hub/recipes/blob/master/adder/src/lib.rs)
 
 ### References
 

--- a/website/versioned_docs/version-pre-2.0/development/module/fees.md
+++ b/website/versioned_docs/version-pre-2.0/development/module/fees.md
@@ -286,9 +286,9 @@ payment module drawing inspiration from Transaction Payment.
 ### Examples
 
 Substrate Recipes contains examples of both [custom
-weights](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/pallets/weights) and
+weights](https://github.com/substrate-developer-hub/recipes/tree/master/pallets/weights) and
 custom
-[WeightToFee](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen/runtimes/weight-fee-runtime).
+[WeightToFee](https://github.com/substrate-developer-hub/recipes/tree/master/runtimes/weight-fee-runtime).
 
 ### References
 

--- a/website/versioned_docs/version-pre-2.0/development/module/tests.md
+++ b/website/versioned_docs/version-pre-2.0/development/module/tests.md
@@ -127,4 +127,4 @@ fn my_runtime_test() {
 
 ## Next Steps
 
-The [testing](https://substrate.dev/recipes/testing/index.html) chapter of the [Substrate Recipes](https://github.com/substrate-developer-hub/recipes/) compliments the samples shown above, and the [kitchen](https://github.com/substrate-developer-hub/recipes/tree/master/kitchen) provides an environment to run the tests, change the logic, and tinker with the code.
+The [testing chapter](https://substrate.dev/recipes/testing/index.html) of the Substrate Recipes compliments the samples shown above, and provides an environment to run the tests, change the logic, and tinker with the code.


### PR DESCRIPTION
This companion PR updates links from Devhub to Recipes to match the new directory structure in https://github.com/substrate-developer-hub/recipes/pull/143

This should not be merged until that one is merged.