### PR TITLE
Run tests in `--release` mode.

### DIFF
--- a/docs/overview/getting-started.md
+++ b/docs/overview/getting-started.md
@@ -18,7 +18,7 @@ Know that we are very happy to help you get started building with Substrate, so 
 
 To develop in the Substrate ecosystem, you must set up your developer environment. Depending on your operating system, these instructions may be different.
 
-## Fast Installation 
+## Fast Installation
 
 ### Unix Based Operating Systems
 
@@ -120,7 +120,7 @@ cargo build --release
 Test the project with:
 
 ```
-cargo test --all
+cargo test --release --all
 ```
 
 Start the Substrate node with:

--- a/website/versioned_docs/version-pre-v2.0-3e65111/overview/getting-started.md
+++ b/website/versioned_docs/version-pre-v2.0-3e65111/overview/getting-started.md
@@ -19,7 +19,7 @@ Know that we are very happy to help you get started building with Substrate, so 
 
 To develop in the Substrate ecosystem, you must set up your developer environment. Depending on your operating system, these instructions may be different.
 
-## Fast Installation 
+## Fast Installation
 
 ### Unix Based Operating Systems
 
@@ -121,7 +121,7 @@ cargo build --release
 Test the project with:
 
 ```
-cargo test --all
+cargo test --release --all
 ```
 
 Start the Substrate node with:


### PR DESCRIPTION
As pointed out in #476 building the node in release mode then running tests in debug mode doesn't make sense because the entire node will be built again in debug mode. May as well run tests in release mode since we've already built the node that way.