### PR TITLE
Front end template tag

### DIFF
--- a/website/versioned_docs/version-pre-v2.0-3e65111/tutorials/build-a-dapp/prepare.md
+++ b/website/versioned_docs/version-pre-v2.0-3e65111/tutorials/build-a-dapp/prepare.md
@@ -28,7 +28,7 @@ Now you can proceed to setup the front-end template with these commands.
 
 ```bash
 # Clone the code from github
-git clone https://github.com/substrate-developer-hub/substrate-front-end-template
+git clone -b pre-v2.0-3e65111 https://github.com/substrate-developer-hub/substrate-front-end-template
 
 # Install the dependencies
 cd front-end-template


### PR DESCRIPTION
Now that the front end template has tagged versions, the older version of the PoE dApp tutorial should explicitly reference the correct version of the front end template.

This is sort of a followup to #493 