### PR TITLE
Update tutorials to alpha.5

### DIFF
--- a/docs/tutorials/build-a-dapp/pallet.md
+++ b/docs/tutorials/build-a-dapp/pallet.md
@@ -4,22 +4,22 @@ title: Building a Custom Pallet
 
 The Substrate runtime is composed of FRAME pallets. You can think of these pallets as individual
 pieces of logic that define what your blockchain can do! Substrate provides you with a number of
-pre-built pallets built with the FRAME framework.
+pre-built pallets for use in FRAME-based runtimes.
 
 ![Runtime Composition](assets/runtime.png)
 
 For example, FRAME includes a
-[Balances](https://substrate.dev/rustdocs/master/pallet_balances/index.html) pallet that controls
+[Balances](https://substrate.dev/rustdocs/v2.0.0-alpha.5/pallet_balances/index.html) pallet that controls
 the underlying currency of your blockchain by managing the _balance_ of all the accounts in your
 system.
 
 If you want to add smart contract functionality to your blockchain, you simply need to include the
-[Contracts](https://substrate.dev/rustdocs/master/pallet_contracts/index.html) pallet.
+[Contracts](https://substrate.dev/rustdocs/v2.0.0-alpha.5/pallet_contracts/index.html) pallet.
 
 Even things like on-chain governance can be added to your blockchain by including pallets like
-[Democracy](https://substrate.dev/rustdocs/master/pallet_democracy/index.html),
-[Elections](https://substrate.dev/rustdocs/master/pallet_elections/index.html), and
-[Collective](https://substrate.dev/rustdocs/master/pallet_collective/index.html).
+[Democracy](https://substrate.dev/rustdocs/v2.0.0-alpha.5/pallet_democracy/index.html),
+[Elections](https://substrate.dev/rustdocs/v2.0.0-alpha.5/pallet_elections/index.html), and
+[Collective](https://substrate.dev/rustdocs/v2.0.0-alpha.5/pallet_collective/index.html).
 
 The goal of this tutorial is to teach you how to create your own Substrate pallet to include
 in your custom blockchain! The `substrate-node-template` comes with a template pallet that
@@ -59,9 +59,10 @@ substrate-node-template
 +-- ...
 ```
 
-You will see some pre-written code which acts as a template for a new pallet. You can delete the
-contents of this file since we will start from scratch for full transparency. When writing your own
-pallets in the future, you will likely find the scaffolding in this template pallet useful.
+You will see some pre-written code which acts as a template for a new pallet. You read over this
+file if you like, and then delete the contents since we will start from scratch for full
+transparency. When writing your own pallets in the future, you will likely find the scaffolding in
+this template pallet useful.
 
 ## Build Your New Pallet
 
@@ -114,9 +115,7 @@ Most of these imports are already available because they were used in the templa
 ```toml
 [dependencies.sp-std]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-rev = '013c1ee167354a08283fb69915fda56a62fee943'
-version = '2.0.0-alpha.3'
+version = '2.0.0-alpha.5'
 ```
 
 Then, **Update** the existing `[features]` block to look like this. The last line is new.
@@ -165,7 +164,7 @@ Our pallet will only have two events:
 1. When a new proof is added to the blockchain.
 2. When a proof is removed.
 
-The events can contain some metadata, in this case, each event will also display who triggered the
+The events can contain some additional data, in this case, each event will also display who triggered the
 event (`AccountId`), and the proof data (as `Vec<u8>`) that is being stored or removed.
 
 ## Pallet Errors
@@ -200,13 +199,13 @@ decl_storage! {
     trait Store for Module<T: Trait> as TemplateModule {
         /// The storage item for our proofs.
         /// It maps a proof to the user who made the claim and when they made it.
-        Proofs: map hasher(blake2_256) Vec<u8> => (T::AccountId, T::BlockNumber);
+        Proofs: map hasher(blake2_128_concat) Vec<u8> => (T::AccountId, T::BlockNumber);
     }
 }
 ```
 
 If a proof has an owner and a block number, then we know that it has been claimed! Otherwise, the
-proof is still available to be claimed.
+proof is available to be claimed.
 
 ### Callable Pallet Functions
 
@@ -227,7 +226,7 @@ decl_module! {
         // this includes information about your errors in the node's metadata.
         // it is needed only if you are using errors in your pallet
         type Error = Error<T>;
-    
+
         // A default function for depositing events
         fn deposit_event() = default;
 
@@ -275,7 +274,7 @@ decl_module! {
 ```
 
 > The functions you see here do not have return types explicitly stated. In reality they all return
-> [`DispatchResult`](https://substrate.dev/rustdocs/v2.0.0-alpha.3/frame_support/dispatch/type.DispatchResult.html)s.
+> [`DispatchResult`](https://substrate.dev/rustdocs/v2.0.0-alpha.5/frame_support/dispatch/type.DispatchResult.html)s.
 > This return type is added on your behalf by the `decl_module!` macro.
 
 ## Compile Your New Pallet

--- a/docs/tutorials/build-a-dapp/prepare.md
+++ b/docs/tutorials/build-a-dapp/prepare.md
@@ -4,7 +4,7 @@ title: Prepare to build a dApp
 
 ## Install the Node Template
 
-You should already have version `v2.0.0-alpha.3` of the [Substrate Node
+You should already have version `v2.0.0-alpha.5` of the [Substrate Node
 Template](https://github.com/substrate-developer-hub/substrate-node-template) compiled on your
 computer from when you completed the [Creating Your First Substrate Chain
 Tutorial](tutorials/creating-your-first-substrate-chain/index.md). If you do not, please complete that
@@ -14,8 +14,9 @@ tutorial.
 
 ## Install the Front End Template
 
-This tutorial also uses a ReactJS front end, which we will modify for interacting with our
-custom Substrate blockchain.
+This tutorial also uses a ReactJS front end template, which we will modify for interacting with our
+custom Substrate blockchain. You can use this same template to create front-ends for your own
+projects in the future.
 
 To use the front-end template, you need [Yarn](https://yarnpkg.com), which itself requires  [Node.js](https://nodejs.org/). If you don't have these tools, you may install them from these instructions:
 
@@ -26,7 +27,7 @@ Now you can proceed to set up the front-end template with these commands.
 
 ```bash
 # Clone the code from github
-git clone -b v2.0.0-alpha.3 https://github.com/substrate-developer-hub/substrate-front-end-template
+git clone -b v2.0.0-alpha.5 https://github.com/substrate-developer-hub/substrate-front-end-template
 
 # Install the dependencies
 cd substrate-front-end-template

--- a/docs/tutorials/creating-a-runtime-module.md
+++ b/docs/tutorials/creating-a-runtime-module.md
@@ -5,54 +5,38 @@ title: "Creating an External Pallet"
 In this tutorial, you'll write a Substrate pallet that lives in its own
 crate, and include it in a node based on the `substrate-node-template`.
 
-## Prerequisites
+## Install the Node Template
 
-If you haven't already done so, follow the [Getting Started](getting-started.md)
-guide to download necessary tools to build Substrate.
+You should already have version `v2.0.0-alpha.5` of the [Substrate Node
+Template](https://github.com/substrate-developer-hub/substrate-node-template) compiled on your
+computer from when you completed the [Creating Your First Substrate Chain
+Tutorial](tutorials/creating-your-first-substrate-chain/index.md). If you do not, please complete that
+tutorial.
 
-### Clone the Node and Pallet Templates
+> Experienced developers who truly prefer to skip that tutorial, you may install the node template according to the instructions in its readme.
+
+### Clone the Pallet Template
 
 We're not going to write our pallet directly as part of the node template, but
 rather as a separate Rust crate. This approach allows us to publish our pallet
-separate from our node and also allows other to easily import this pallet into
+separately from our node and also allows others to easily import this pallet into
 their own Substrate runtime.
 
-1. Clone the Substrate node template:
+Clone the Substrate pallet template in the `pallets` directory of your node template:
 
-    ```bash
-    git clone -b v2.0.0-alpha.3 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template my-node
-    ```
+```bash
+cd pallets
+git clone -b v2.0.0-alpha.5 https://github.com/substrate-developer-hub/substrate-pallet-template test-pallet
+```
 
-2. Clone the Substrate pallet template in the `pallets` directory of your node template:
-
-    ```bash
-    git clone -b v2.0.0-alpha.3 https://github.com/substrate-developer-hub/substrate-pallet-template my-pallet
-    ```
-
-3. Build the Substrate node template:
-
-    ```bash
-    cd my-node
-    cargo build --release
-    ```
-
-The `substrate-node-template` contains a working Substrate node, and the
-`substrate-pallet-template` contains an independent Rust crate which is a
-Substrate pallet that can be included in your node. The compilation of
-the node may take up to 30 minutes depending on your hardware, so let that run
-while you continue to follow this guide.
-
-If you aren't familiar with Rust including and using other pallets, you can
-refer to [the Cargo
-book](https://doc.rust-lang.org/cargo/guide/creating-a-new-project.html) for a
-more in-depth explanation.
+> In this tutorial we have placed the pallet template _inside_ the node template's directory structure. This pattern is not required, and you can place the pallet template anywhere you like. Another popular option would be as a _sibling_ to the node template.
 
 ## The Substrate Pallet Template
 
 You should be able to successfully compile the Substrate pallet template with:
 
 ```bash
-cd my-pallet
+cd test-pallet
 cargo build --release
 ```
 
@@ -67,7 +51,7 @@ writing interesting pallet logic. So let's call it `test-pallet`.
 
 The beginning of the `Cargo.toml` now looks like:
 
-**`my-node/pallets/my-pallet/Cargo.toml`**
+**`pallets/test-pallet/Cargo.toml`**
 
 ```toml
 [package]
@@ -79,7 +63,7 @@ edition = "2018"
 
 ### Your Pallet's `std` Feature
 
-In your `my-node/pallets/my-pallet/Cargo.toml` file, you will notice a few lines about the
+In your `pallets/test-pallet/Cargo.toml` file, you will notice a few lines about the
 "`std` feature". In Rust, when you enable `std`, you give your project access to
 [the Rust standard libraries](https://doc.rust-lang.org/std/). This works just
 fine when building native binaries.
@@ -91,7 +75,7 @@ compile with [`no_std`](https://rust-embedded.github.io/book/intro/no-std.html)
 feature. Our `Cargo.toml` file tells our pallet's dependencies to only use their
 `std` feature when this pallet also uses its `std` feature, like so:
 
-**`my-node/pallets/my-pallet/Cargo.toml`**
+**`pallets/test-pallet/Cargo.toml`**
 
 ```TOML
 [features]
@@ -107,51 +91,35 @@ std = [
 ### Consistent Substrate Dependencies
 
 All Substrate pallets will depend on some low-level FRAME libraries such as
-`frame-system` and `frame-support`. These libraries are pulled from the main
-[Substrate GitHub repository](https://github.com/paritytech/substrate). When
-people build their own Substrate nodes, they will also have dependencies on the
-main Substrate repository.
+`frame-system` and `frame-support`. These libraries are pulled from crates.io. When
+people build their own FRAME-based runtimes, they will also have dependencies on these  low-level libraries. You will need to ensure consistent dependencies between your pallet and your runtime.
 
-Because of this, you will need to be careful to ensure consistent dependencies
-from your pallet and the your Substrate node. If your pallet is dependent on
-one version of Substrate, and the node on another, compilation will run into errors
-where the Substrate versions may be incompatible, or different version of the
-same library are being used.
-Ultimately Cargo will not be able to resolve those conflicts and you will get a
-compile time error.
-
-**`my-node/pallets/my-pallet/Cargo.toml`**
+**`pallets/test-pallet/Cargo.toml`**
 
 ```TOML
 # --snip--
 
 [dependencies.frame-support]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-rev = '013c1ee167354a08283fb69915fda56a62fee943'
-version = '2.0.0-alpha.3'
-
-# Develop against a git commit by specifying the same Substrate commit as your main node.
-# It is important to use the same Substrate commit to prevent dependencies mismatch.
-
+version = '2.0.0-alpha.5'
 ```
+
+From the above snippet, we see that this pallet template depends on version `2.0.0-alpha.5` of the low-level libraries. Thus it can be used in runtimes that also depend on `2.0.0-alpha.5`.
 
 ### Your Pallet's Dev Dependencies
 
 The final section of the `Cargo.toml` file specifies the dev dependencies. These
-are the dependencies that are needed in your pallet's tests, but not necessary
+are the dependencies that are needed in your pallet's tests, but not
 the actual pallet itself.
 
-**`my-node/pallets/my-pallet/Cargo.toml`**
+**`pallets/test-pallet/Cargo.toml`**
 
 ```TOML
 # --snip--
 
 [dev-dependencies.sp-core]
 default-features = false
-git = 'https://github.com/paritytech/substrate.git'
-rev = '013c1ee167354a08283fb69915fda56a62fee943'
-version = '2.0.0-alpha.3'
+version = '2.0.0-alpha.5'
 ```
 
 You can confirm that the tests in the Substrate pallet template pass with:
@@ -160,25 +128,29 @@ You can confirm that the tests in the Substrate pallet template pass with:
 cargo test
 ```
 
-You may need to modify the dependencies you need for the pallets you create.
+When updating this pallet to include your own custom logic, you will likely add dependencies of your own to this `Cargo.toml` file.
 
 ## Add Your Pallet to Your Node
 
 With our pallet now compiling and passing it's tests, we're ready to add
 it to our node.
 
+> If you aren't familiar with including and using other crates, refer to [the Cargo
+> book](https://doc.rust-lang.org/cargo/guide/creating-a-new-project.html) for an
+> in-depth explanation.
+
 We first add our newly-created crate as a dependency in the node's runtime
 `Cargo.toml`. Then we tell the pallet to only build its `std` feature when the
 runtime itself does, as follows:
 
-**`my-node/runtime/Cargo.toml`**
+**`runtime/Cargo.toml`**
 
 ```TOML
 # --snip--
 
 [dependencies.test-pallet]
 default-features = false
-path = '../pallets/template'
+path = '../pallets/test-pallet'
 
 # toward the bottom
 [features]
@@ -192,11 +164,11 @@ std = [
 > You **must** set `default_features = false` so that your runtime will
 successfully compile to Wasm.
 
-Next we will update `my-node/runtime/src/lib.rs` to actually use our new runtime
+Next we will update `runtime/src/lib.rs` to actually use our new runtime
 pallet, by adding a trait implementation with our `test_pallet` and add it in
 our `construct_runtime!` macro.
 
-**`my-node/runtime/src/lib.rs`**
+**`runtime/src/lib.rs`**
 
 ```rust
 // add the following code block
@@ -226,7 +198,6 @@ your node's runtime.
 1. Compile and run your node with:
 
     ```bash
-    cd my-node
     cargo build --release
     ```
 
@@ -253,16 +224,24 @@ connect to** set to **Local Node**.
 ## Publish Your Pallet
 
 Once your pallet is no longer in test phase, you should consider publishing
-it to GitHub. Go ahead and [create a GitHub
+it to GitHub or crates.io.
+
+### Publishing on GitHub
+To publish on GitHub, you need to [create a GitHub
 repository](https://help.github.com/en/articles/create-a-repo) and [push your
 pallet's code](https://help.github.com/en/articles/pushing-to-a-remote) to it.
 
-With the code on GitHub, your pallet is properly published. Congratulations! Now
-we just need to update your node to use the code that is on GitHub instead of a
-hard-coded file system path. The final edit to your runtime's `Cargo.toml` file
-is to update its dependency on your pallet. The new code is:
+### Publishing on Crates.io
+Crates.io allows permissionless publishing. Learn the proceedure following their own guide about [publishing on crates.io](https://doc.rust-lang.org/cargo/reference/publishing.html)
 
-**`my-node/runtime/Cargo.toml`**
+## Updating your Runtime's Dependecy
+With your pallet now published on GitHub, crates.io, or both,
+we can update your runtime to use the code that is published instead of a
+hard-coded file system path.
+
+### Dependencies from GitHub
+
+**`runtime/Cargo.toml`**
 
 ```TOML
 [dependencies.your-pallet-name]
@@ -275,27 +254,32 @@ branch = 'master'
 # tag = '<some tag>
 ```
 
-Compile one more time and notice that Cargo now grabs your pallet from GitHub
-instead of using the local files.
+### Dependencies from Crates.io
+
+**`runtime/Cargo.toml`**
+
+```TOML
+[dependencies.your-pallet-name]
+default_features = false
+version = 'some-compatible-version'
+```
+
+## One Last Build
+
+Compile one more time and notice that Cargo now grabs your pallet from GitHub or crates.io instead of using the local files.
 
 ## Next Steps
 
 Congratulations! You've written a Substrate pallet in its own Rust
-crate, and published that crate to GitHub. Other blockchain developers can now
+crate, and published it. Other blockchain developers can now
 easily use your pallet in their runtime by simply including those same four
 lines of code in their runtime's `Cargo.toml` files and updating their runtime's
 `lib.rs` file.
-
-If you're not sure what to do next, check out the resources below.
 
 ### Learn More
 
 - We have [plenty of tutorials](https://substrate.dev/en/tutorials) to showcase
   Substrate development concepts and techniques.
-- To learn more about writing your own runtime with a front end, we have a
-  [Substrate Collectables
-  Workshop](https://substrate.dev/substrate-collectables-workshop) for building
-  an end-to-end application.
 - For more information about runtime development tips and patterns, refer to our
   [Substrate Recipes](https://substrate.dev/recipes/).
 

--- a/docs/tutorials/creating-your-first-substrate-chain/interact.md
+++ b/docs/tutorials/creating-your-first-substrate-chain/interact.md
@@ -24,7 +24,7 @@ $ ./target/release/node-template --dev
 
 2020-03-11 07:42:55 Running in --dev mode, RPC CORS has been disabled.
 2020-03-11 07:42:55 Substrate Node
-2020-03-11 07:42:55   version 2.0.0-alpha.3-5b41f0b-x86_64-linux-gnu
+2020-03-11 07:42:55   version 2.0.0-alpha.5-da88e4a-x86_64-linux-gnu
 2020-03-11 07:42:55   by Anonymous, 2017-2020
 2020-03-11 07:42:55 Chain specification: Development
 2020-03-11 07:42:55 Node name: deranged-faucet-4432
@@ -70,7 +70,7 @@ Success", and of course Charlie's balance will increase.
 ## Create Your Own Account
 
 You can create your own account by selecting the `+ Add Account` button. It won't have any tokens
-yet, but you can send some from Alice or any other pre-funded account. Only you will (and your
+yet, but you can send some from Alice or any other pre-funded account. Only you (and your
 browser) will know the private key for your own account which means nobody can transfer those tokens
 except you.
 

--- a/docs/tutorials/creating-your-first-substrate-chain/setup.md
+++ b/docs/tutorials/creating-your-first-substrate-chain/setup.md
@@ -51,10 +51,10 @@ well documented [here](overview/getting-started.md).
 Once the prerequisites are installed, you need to set up the skeleton for our project. The Substrate Node
 Template serves as a good starting point for building on Substrate.
 
-1. Clone the Substrate Node Template (version `v2.0.0-alpha.3`).
+1. Clone the Substrate Node Template (version `v2.0.0-alpha.5`).
 
     ```bash
-		git clone -b v2.0.0-alpha.3 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+		git clone -b v2.0.0-alpha.5 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
     ```
 
 2. Initialize your WebAssembly build environment

--- a/docs/tutorials/start-a-private-network/alicebob.md
+++ b/docs/tutorials/start-a-private-network/alicebob.md
@@ -11,9 +11,16 @@ pre-defined (and definitely not private!) keys known as Alice and Bob.
 
 ## Alice Starts First
 
-Alice (or whomever is playing her) should run this command from node-template repository root.
+Alice (or whomever is playing her) should run these commands from node-template repository root.
+
+> Here we've explicitly shown the `purge-chain` command. In the future we will omit this
+> You should purge old chain data any time you're trying to start a new network.
 
 ```bash
+# Purge any chain data from previous runs
+# You will be prompted to type `y`
+./target/release/node-template purge-chain
+
 # Start Alice's node
 ./target/release/node-template \
   --base-path /tmp/alice \
@@ -43,7 +50,7 @@ When the node starts you should see output similar to this.
 
 ```
 2020-03-11 09:39:14 Substrate Node
-2020-03-11 09:39:14   version 2.0.0-alpha.3-5b41f0b-x86_64-linux-gnu
+2020-03-11 09:39:14   version 2.0.0-alpha.5-2ddc70d-x86_64-linux-gnu
 2020-03-11 09:39:14   by Anonymous, 2017-2020
 2020-03-11 09:39:14 Chain specification: Local Testnet
 2020-03-11 09:39:14 Node name: Alice
@@ -95,7 +102,7 @@ Apps UI, by default, connects to the Kusama network. To configure Apps UI to con
     ![Select Network](/docs/assets/private-network-select-network.png)
 
   - To connect to a custom node and port, you just need to specify the endpoint by choosing `custom
-  endpoint` and type in your own endpoint. By this way you can use a single instance of Apps UI to
+  endpoint` and type in your own endpoint. In this way you can use a single instance of Apps UI to
   connect to various nodes.
 
     ![Custom Endpoint](/docs/assets/private-network-custom-endpoint.png)
@@ -136,7 +143,7 @@ Most of these options are already explained above, but there are a few points wo
 * Bob has added the `--bootnodes` flag and specified a single boot node, namely Alice's. He must correctly specify these three pieces of information which Alice can supply for him.
   * Alice's IP Address, in the form `127.0.0.1`
   * Alice's Port, probably `30333`
-  * Alice's Peer ID, copied from the log output. (`QmWirz83uJTFEUVzoshXUf2SY2nTSJetd4nJGkZ7kozZPb`
+  * Alice's Peer ID, copied from her log output. (`QmWirz83uJTFEUVzoshXUf2SY2nTSJetd4nJGkZ7kozZPb`
   in the example output above.)
 
 If all is going well, after a few seconds, the nodes should peer together and start producing blocks.

--- a/docs/tutorials/start-a-private-network/customchain.md
+++ b/docs/tutorials/start-a-private-network/customchain.md
@@ -14,7 +14,7 @@ Last time around, we used `--chain local` which is a predefined "chain spec" tha
 specified as validators along with many other useful defaults.
 
 Rather than writing our chain spec completely from scratch, we'll just make a few modifications to
-the the one we used before. To start we need to export the chain spec to a file named
+the one we used before. To start we need to export the chain spec to a file named
 `customSpec.json`. Remember, further details about all of these commands are available by running
 `node-template --help`.
 
@@ -25,7 +25,7 @@ $ ./target/release/node-template build-spec --chain local > customSpec.json
 ```
 
 The file we just created contains several fields, and you can learn a lot by exploring them. By far
-the largest field is a single hex number that is the Wasm binary of our runtime. It is part of what
+the largest field is a single binary blob that is the Wasm binary of our runtime. It is part of what
 you built earlier when you ran the `cargo build` command.
 
 The portion of the file we're interested in is the Aura authorities used for creating blocks,
@@ -124,7 +124,7 @@ You should see the console outputs something as follows:
 
 ```bash
 2020-01-10 16:50:24 Substrate Node
-2020-01-10 16:50:24   version 2.0.0-alpha.3-5b41f0b-x86_64-linux-gnu
+2020-01-10 16:50:24   version 2.0.0-alpha.5-2ddc70d-x86_64-linux-gnu
 2020-01-10 16:50:24   by Anonymous, 2017, 2018
 2020-01-10 16:50:24 Chain specification: Local Testnet
 2020-01-10 16:50:24 Node name: MyNode01
@@ -144,7 +144,7 @@ You should see the console outputs something as follows:
 ## Add Keys to Keystore
 
 Once your node is running, you will again notice that no blocks are being produced. At this point,
-you need to add your keys into the keystore.
+you need to add your keys into the keystore. Remember you will need to complete these steps for each node in your network.
 
 ### Option 1: Using Polkadot-JS App UI
 
@@ -169,6 +169,8 @@ suri: <your mnemonic phrase> (eg. clip organ olive upper oak void inject side su
 publicKey: <your raw ed25519 key> (eg. 0xb48004c6e1625282313b07d1c9950935e86894a2e4f21fb1ffee9854d180c781)
 ```
 > If you generated your keys with the Apps UI you will not know your raw public key. In this case you may use your SS58 address (`5G9NWJ5P9uk7am24yCKeLZJqXWW6hjuMyRJDmw4ofqxG8Js2`) instead.
+
+> Remember to switch the UIs connection to the second node before repeating these steps.
 
 ### Option 2: Using CLI
 
@@ -262,9 +264,9 @@ validators added their grandpa keys into their keystores.
 
 Congratulations! You've started your own blockchain!
 
-In this tutorial you've learned to compile the node-template, generate your own keypairs, create a
+In this tutorial you've learned to generate your own keypairs, create a
 custom chain spec that uses those keypairs, and start a private network based on your custom chain
-spec and the node-template.
+spec.
 
 ### Learn More
 

--- a/docs/tutorials/start-a-private-network/index.md
+++ b/docs/tutorials/start-a-private-network/index.md
@@ -6,7 +6,7 @@ In this tutorial we will learn and practice how to start a blockchain network wi
 
 ## Install the Node Template
 
-You should already have version `v2.0.0-alpha.3` of the [Substrate Node
+You should already have version `v2.0.0-alpha.5` of the [Substrate Node
 Template](https://github.com/substrate-developer-hub/substrate-node-template) compiled on your
 computer from when you completed the [Creating Your First Substrate Chain
 Tutorial](tutorials/creating-your-first-substrate-chain/index.md). If you do not, please complete that


### PR DESCRIPTION
This PR updates 5 tutorials to `v2.0.0-alpha.5`. I've updated each tutorial in its own commit you reviewers can easily see which tutorials are updated.

Very little has changed API-wise since `alpha.3`, but this is the first time these tutorials take dependencies from crates.io