### PR TITLE
Restore normal (non-deprecated) PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,11 @@
-!!! NOTICE !!!
 
-All documentation has been moved to the Knowledge Base. Please make your PR there.
-
-https://github.com/substrate-developer-hub/knowledge-base/
+- [ ] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
+- [ ] Is the writing:
+  - [ ] Clear: No jargon.
+  - [ ] Precise: No ambiguous meanings.
+  - [ ] Concise: Free of superfluous detail.
+- [ ] Does it follow our style guide?
+- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
+- [ ] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
+- [ ] Do links go to rustdocs or devhub articles rather than code?
+- [ ] If this PR addresses an issue in the queue, have you referenced it in the description?


### PR DESCRIPTION
This PR removes the deprecation notice from the PR template and restores the normal PR checklist. This is part of the migrations back to docusaurus.