### PR TITLE
Add CI to check links

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,0 +1,16 @@
+name: Check Markdown links
+
+on:
+  pull_request:
+    branches:
+    - source
+  push:
+    branches:
+    - source
+
+jobs:
+  markdown-link-check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: gaurav-nelson/github-action-markdown-link-check@v1


### PR DESCRIPTION
This PR adds a github actions CI that checks all the links in the markdown files. Solves #544 

This CI job uses github actions rather than circle CI, but personally I'm fine with that.