### PR TITLE
Reset API key

### DIFF
--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -153,7 +153,7 @@ class Footer extends React.Component {
           </div>
           <div>
             <h5>More</h5>
-            <a href="https://builders.parity.io/">Substrate Builders Program</a>
+            <a href="https://www.substrate.io/builders-program/">Substrate Builders Program</a>
             <a href="https://www.parity.io/blog/">Blog</a>
             <a href="https://github.com/paritytech/substrate">
               Substrate GitHub

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -144,7 +144,7 @@ const siteConfig = {
 
 	// Algolia Search
 	algolia: {
-		apiKey: '9b6167fbfe26440cbf4cd75b254e0425',
+		apiKey: '5cd09916f4ba4c283b2d45ee7386fc34',
 		indexName: 'substrate',
 		algoliaOptions: {
 			// https://www.algolia.com/doc/api-reference/api-parameters/


### PR DESCRIPTION
The automatic crawler was triggered by Algolia's team.
It should be fine to point again to the old index.