### PR TITLE
Redirect Codec page

### DIFF
--- a/docs/conceptual/core/codec.md
+++ b/docs/conceptual/core/codec.md
@@ -1,0 +1,3 @@
+<meta http-equiv="Refresh" content="0; url=../../knowledgebase/advanced/codec" />
+
+View the latest docs on the [SCALE codec](../../knowledgebase/advanced/codec).


### PR DESCRIPTION
This PR adds a redirect from a previous location of the scale codec doc to the new one. Specifically it adds a redirect from `substrate.dev/docs/en/conceptual/core/codec` to `substrate.dev/docs/en/knowledgebase/advanced/codec`.

There are several weaknesses of this approach to redirects.
1. It requires creating a file in our directory for each old location that we want to redirect.
2. It does _not_ redirect the other old location for this doc `substrate.dev/docs/en/next/conceptual/core/codec

If it is possible it would be preferable to implement the redirect at the DNS / cloudflare level. cc @lovelaced