### PR TITLE
Custom redirect for broken pages

### DIFF
--- a/website/pages/en/404.js
+++ b/website/pages/en/404.js
@@ -34,7 +34,7 @@ class ErrorPage extends React.Component {
           !
         </p>
          <p>
-       Alternatively, if you arrive here via a dead link, look at the most recent <a href="https://github.com/paritytech/substrate">documentation</a> and contributions.
+       Alternatively, if you arrive here via a dead link, return to the <a href="https://substrate.dev/docs/">documentation homepage</a>.
       </p>
         <p>
           <Button href="/" variant="secondary" className="primary-color">

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -88,6 +88,7 @@ const siteConfig = {
 		'/js/clipboard.min.js',
 		'/js/code-block-buttons.js',
 		'/js/load.js',
+		'/js/redirect-next.js',
 		{
 			src: '/js/ui.js',
 			defer: true

--- a/website/static/js/redirect-next.js
+++ b/website/static/js/redirect-next.js
@@ -1,0 +1,33 @@
+window.addEventListener("load", function() {
+    let pathname = window.location.pathname;
+
+    // Full, hardcoded redirects based on current path
+    let redirects = {
+        // "/impossible/example/page/": "/new/page/here/"
+    };
+    // Custom full redirects first
+    if (pathname in redirects) {
+        window.location.href = redirects[pathname];
+        return;
+    }
+
+    // We want to redirect:
+    // * https://substrate.dev/docs/next/...
+    // ------------------------^ [1] ^[2]
+    // * https://substrate.dev/docs/en/next/...
+    // ------------------------^ [1] --^ [3]
+    // pathArray[0] is an empty string
+
+    var pathArray = pathname.split('/');
+
+    // General redirect of user from `next` to `knowledgebase`
+    if (pathArray[1] == 'docs') {
+        if (pathArray[2] == 'next') {
+            pathArray[2] = 'knowledgebase';
+            window.location.href = pathArray.join('/');
+        } else if (pathArray[3] == 'next') {
+            pathArray[3] = 'knowledgebase';
+            window.location.href = pathArray.join('/');
+        }
+    }
+});


### PR DESCRIPTION
This adds a small JS script to every page of the developer hub.

We check the current url, and see if any of the desired redirect patterns match.

If so, we take the user to the new page, leaving the old page in history.

This script currently replaces instances of `docs/en/next` or `docs/next` with `docs/en/knolwedgebase` or `docs/knolwedgebase` which should handle the majority situation.

Custom full redirects beyond that can be added given the template I have provided, or this script can be modified for the needs of the site.