### PR TITLE
Added `fn` to storage getters.

### DIFF
--- a/docs/knowledgebase/runtime/pallets.md
+++ b/docs/knowledgebase/runtime/pallets.md
@@ -94,10 +94,10 @@ decl_storage! {
 	trait Store for Module<T: Trait> as Example {
 		// The last value passed to `set_value`.
 		// Used as an example of a `StorageValue`.
-		pub LastValue get(last_value): u64;
+		pub LastValue get(fn last_value): u64;
 		// The value each user has put into `set_value`.
 		// Used as an example of a `StorageMap`.
-		pub UserValue get(user_value): map T::AccountId => u64;
+		pub UserValue get(fn user_value): map T::AccountId => u64;
 	}
 }
 


### PR DESCRIPTION
Upon trying to debug some substrate code and looking through the docs, I saw that there was some discrepancies between the [substrate recipes book](https://substrate.dev/recipes/2-appetizers/2-storage-values.html) and this document with regards to declaring getters for storage variables. 

I have amended the example code to be in line with the recipe code.