### PR TITLE
Crib linkchecker from w3f

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -80,19 +80,21 @@ jobs:
         - checkout
         - run:
             name: build
+            working_directory: website
             command: |
               yarn
         - run:
             name: serve
+            working_directory: website
             background: true
             command: |
-              yarn polkadot:start
+              yarn start
         - run:
-            name: wait website up
+            name: wait serve
             command: |
               while ! nc -z localhost 3000; do
                 sleep 1
-                echo waiting for website up...
+                echo waiting for website to start...
               done
         - run:
             name: check links

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,24 +74,30 @@ jobs:
             cd website && yarn install && yarn run write-translations && yarn build
 
   check-links:
-    docker:
-      # specify the version you desire here
-      - image: circleci/node:10.15.2
-    steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "a1:f6:36:72:14:54:c0:37:47:fe:0f:c1:01:7f:21:f5"
-      - checkout
-      - run:
-          name: Check if Links Work
-          working_directory: website
-          command: |
-            yarn && (yarn start &) && sleep 10 && yarn blc http://localhost:3000 -ro \
-            --exclude "http://localhost:3000/docs/ru" \
-            --exclude "http://localhost:3000/docs/zh-CN" \
-            --exclude "https://playground.substrate.dev/" \
-            --exclude "https://player.twitch.tv/?channel=paritylivecoding" \
-            --exclude "http://localhost:8000/"
+      docker:
+        - image: web3f/link-checker:v1.0.1
+      steps:
+        - checkout
+        - run:
+            name: build
+            command: |
+              yarn
+        - run:
+            name: serve
+            background: true
+            command: |
+              yarn polkadot:start
+        - run:
+            name: wait website up
+            command: |
+              while ! nc -z localhost 3000; do
+                sleep 1
+                echo waiting for website up...
+              done
+        - run:
+            name: check links
+            command: |
+              linkchecker --ignore-url="^(?:(?!\/en\/).)*$" --check-extern http://localhost:3000/
 
 workflows:
   version: 2


### PR DESCRIPTION
This PR replaces the previous linkchecker (blc) with the custom docker image that the [w3f uses](https://github.com/w3f/polkadot-wiki/blob/936ab5a10ee162a4fcb1c20e0b816d3cea11d963/.circleci/config.yml#L15-L42) in the Polkadot wiki.

This is a naive copy paste job just to see if it works. It may give us trouble because of international docs. I noticed they were excluded in the previous linkcheck. Let's just see.


Next attempt if this one also fails:
We could use https://github.com/gaurav-nelson/github-action-markdown-link-check as we do [in the Recipes](https://github.com/substrate-developer-hub/recipes/blob/master/.github/workflows/link-check.yml). It hasn't been perfect, but it has been pretty good and it isn't blocking several PRs from being merged all because of HTTP 429