### PR TITLE
Minor Overhaul

### DIFF
--- a/docs/knowledgebase/advanced/block-import.md
+++ b/docs/knowledgebase/advanced/block-import.md
@@ -15,22 +15,22 @@ are later checked for validity and discarded if they are not valid. Elements tha
 imported into the node's local state.
 
 The import queue is codified abstractly in Substrate by means of the
-[`ImportQueue` trait](https://crates.parity.io/sp_consensus/import_queue/trait.ImportQueue.html).
+[`ImportQueue` trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_consensus/import_queue/trait.ImportQueue.html).
 The use of a trait allows each consensus engine to provide its own specialized implementation of the
 import queue, which may take advantage of optimization opportunities such as verifying multiple
 blocks in parallel as they come in across the network.
 
 The import queue also provides some hooks via the
-[`Link` trait](https://crates.parity.io/sp_consensus/import_queue/trait.Link.html) that can be used
+[`Link` trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_consensus/import_queue/trait.Link.html) that can be used
 to follow its progress.
 
 ## The Basic Queue
 
 Substrate provides a default in-memory implementation of the `ImportQueue` known as the
-[`BasicQueue`](https://crates.parity.io/sp_consensus/import_queue/struct.BasicQueue.html). The
+[`BasicQueue`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_consensus/import_queue/struct.BasicQueue.html). The
 `BasicQueue` does not do any kind of optimization, rather it performs the verification and import
 steps sequentially. It does, however, abstract the notion of verification through the use of the
-[`Verifier`](https://crates.parity.io/sp_consensus/import_queue/trait.Verifier.html) trait.
+[`Verifier`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_consensus/import_queue/trait.Verifier.html) trait.
 
 Any consensus engine that relies on the `BasicQueue` must implement the `Verifier` trait. The
 `Verifier` is typically responsible for tasks such as checking
@@ -41,12 +41,12 @@ the block is signed by the appropriate authority.
 
 When the import queue is ready to import a block, it passes the block in question to a method
 provided by the
-[`BlockImport` trait](https://crates.parity.io/sp_consensus/block_import/trait.BlockImport.html).
+[`BlockImport` trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_consensus/block_import/trait.BlockImport.html).
 This `BlockImport` trait provides the behavior of importing a block into the node's local state
 database.
 
 One implementor of the `BlockImport` trait that is used in every Substrate node is the
-[`Client`](https://crates.parity.io/sc_service/client/index.html), which contains the node's entire
+[`Client`](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_service/client/index.html), which contains the node's entire
 block database. When a block is imported into the client, it is added to the main database of blocks
 that the node knows about.
 
@@ -59,13 +59,13 @@ another struct that also implements `BlockImport`. This nesting leads to the ter
 pipeline".
 
 An example of this wrapping is the
-[`PowBlockImport`](https://crates.parity.io/sc_consensus_pow/struct.PowBlockImport.html), which
+[`PowBlockImport`](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_consensus_pow/struct.PowBlockImport.html), which
 holds a reference to another type that also implements `BlockImport`. This allows the PoW consensus
 engine to do its own import-related bookkeeping and then pass the block to the nested `BlockImport`,
 probably the client. This pattern is also demonstrated in
-[`AuraBlockImport`](https://crates.parity.io/sc_consensus_aura/struct.AuraBlockImport.html),
-[`BabeBlockImport`](https://crates.parity.io/sc_consensus_babe/struct.BabeBlockImport.html), and
-[`GrandpaBlockImport`](https://crates.parity.io/sc_finality_grandpa/struct.GrandpaBlockImport.html).
+[`AuraBlockImport`](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_consensus_aura/struct.AuraBlockImport.html),
+[`BabeBlockImport`](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_consensus_babe/struct.BabeBlockImport.html), and
+[`GrandpaBlockImport`](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_finality_grandpa/struct.GrandpaBlockImport.html).
 
 `BlockImport` nesting need not be limited to one level. In fact, it is common for nodes that use
 both an authoring engine and a finality gadget to layer the nesting even more deeply. For example,

--- a/docs/knowledgebase/advanced/codec.md
+++ b/docs/knowledgebase/advanced/codec.md
@@ -201,7 +201,7 @@ that is written in Rust and maintained by Parity Technologies.
 ## References
 
 - Visit the reference docs for the
-  [`parity-scale-codec`](https://crates.parity.io/parity_scale_codec/index.html).
+  [`parity-scale-codec`](https://substrate.dev/rustdocs/v2.0.0-rc4/parity_scale_codec/index.html).
 
 - Visit the auxiliary encoding section of the
   [Polkadot runtime environment specification](https://github.com/w3f/polkadot-spec/).

--- a/docs/knowledgebase/advanced/consensus.md
+++ b/docs/knowledgebase/advanced/consensus.md
@@ -50,7 +50,7 @@ parent. Forks must be resolved such that only one, canonical chain exists.
 
 A fork choice rule is an algorithm that takes a blockchain and selects the "best" chain, and thus
 the one that should be extended. Substrate exposes this concept through the
-[`SelectChain` Trait](https://crates.parity.io/sp_consensus/trait.SelectChain.html).
+[`SelectChain` Trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_consensus/trait.SelectChain.html).
 
 Substrate allows you to write a custom fork choice rule, or use one that comes out of the box. For
 example:
@@ -59,7 +59,7 @@ example:
 
 The longest chain rule simply says that the best chain is the longest chain. Substrate provides this
 chain selection rule with the
-[`LongestChain` struct](https://crates.parity.io/sc_consensus/struct.LongestChain.html).
+[`LongestChain` struct](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_consensus/struct.LongestChain.html).
 GRANDPA uses the longest chain rule for voting.
 
 ![longest chain rule](assets/consensus-longest-chain.png)
@@ -129,12 +129,12 @@ Developers are always welcome to provide their own custom consensus algorithms.
 
 ### Aura
 
-[Aura](https://crates.parity.io/sc_consensus_aura/index.html) provides a slot-based
+[Aura](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_consensus_aura/index.html) provides a slot-based
 block authoring mechanism. In Aura a known set of authorities take turns producing blocks.
 
 ### BABE
 
-[BABE](https://crates.parity.io/sc_consensus_babe/index.html) also provides slot-based
+[BABE](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_consensus_babe/index.html) also provides slot-based
 block authoring with a known set of validators. In these ways it is similar to Aura. Unlike Aura,
 slot assignment is based on the evaluation of a Verifiable Random Function (VRF). Each validator is
 assigned a weight for an _epoch._ This epoch is broken up into slots and the validator evaluates its
@@ -149,7 +149,7 @@ in a given slot. These "secondary" slot assignments allow BABE to achieve a cons
 
 ### Proof of Work
 
-[Proof-of-work](https://crates.parity.io/sc_consensus_pow/index.html) block authoring
+[Proof-of-work](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_consensus_pow/index.html) block authoring
 is not slot-based and does not require a known authority set. In proof of work, anyone can produce a
 block at any time, so long as they can solve a computationally challenging problem (typically a hash
 preimage search). The difficulty of this problem can be tuned to provide a statistical target block
@@ -157,7 +157,7 @@ time.
 
 ### GRANDPA
 
-[GRANDPA](https://crates.parity.io/sc_finality_grandpa/index.html) provides block
+[GRANDPA](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_finality_grandpa/index.html) provides block
 finalization. It has a known weighted authority set like BABE. However, GRANDPA does not author
 blocks; it just listens to gossip about blocks that have been produced by some authoring engine like
 the three discussed above. GRANDPA validators vote on _chains,_ not _blocks,_ i.e. they vote on a
@@ -173,7 +173,7 @@ coordination with the runtime. Examples include adjustable difficulty in proof o
 rotation in proof of authority, and stake-based weighting in proof-of-stake networks.
 
 To accommodate these consensus features, Substrate has the concept of a
-[`DigestItem`](https://crates.parity.io/sp_runtime/enum.DigestItem.html), a message
+[`DigestItem`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/enum.DigestItem.html), a message
 passed from the outer part of the node, where consensus lives, to the runtime, or vice versa.
 
 ## Learn More

--- a/docs/knowledgebase/advanced/cryptography.md
+++ b/docs/knowledgebase/advanced/cryptography.md
@@ -9,7 +9,7 @@ This document offers a conceptual overview of the cryptography used in Substrate
 Hash functions are used in Substrate to map arbitrary sized data to fixed-sized values.
 
 Substrate provides two hash algorithms out of the box, but can support any hash algorithm which
-implements the [`Hasher` trait](https://crates.parity.io/sp_core/trait.Hasher.html).
+implements the [`Hasher` trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_core/trait.Hasher.html).
 
 ### xxHash
 
@@ -39,7 +39,7 @@ Public-key cryptography is used in Substrate to provide a robust authentication 
 
 Substrate provides multiple different cryptographic schemes and is generic such that it can support
 anything which implements the
-[`Pair` trait](https://crates.parity.io/sp_core/crypto/trait.Pair.html).
+[`Pair` trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_core/crypto/trait.Pair.html).
 
 ### ECDSA
 
@@ -87,7 +87,7 @@ but only ECDSA signatures communicate their public key.
 ### References
 
 - Take a look at the
-  [`Hash`](https://crates.parity.io/sp_runtime/traits/trait.Hash.html) trait needed for
+  [`Hash`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/traits/trait.Hash.html) trait needed for
   implementing new hashing algorithms.
-- Take a look at the [`Pair`](https://crates.parity.io/sp_core/crypto/trait.Pair.html)
+- Take a look at the [`Pair`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_core/crypto/trait.Pair.html)
   trait needed for implementing new cryptographic schemes.

--- a/docs/knowledgebase/advanced/executor.md
+++ b/docs/knowledgebase/advanced/executor.md
@@ -69,7 +69,7 @@ needs to know the `spec_name`, `spec_version` and `authoring_version` of both th
 runtime.
 
 The runtime provides the following
-[versioning properties](https://crates.parity.io/sp_version/struct.RuntimeVersion.html):
+[versioning properties](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_version/struct.RuntimeVersion.html):
 
 - `spec_name`: The identifier for the different Substrate runtimes.
 
@@ -128,10 +128,10 @@ TODO
 ### References
 
 - Check out the different
-  [Execution Strategies](https://crates.parity.io/sc_client_api/execution_extensions/struct.ExecutionStrategies.html).
+  [Execution Strategies](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_client_api/execution_extensions/struct.ExecutionStrategies.html).
 
 - Take a look at the different
-  [Execution Strategy Options](https://crates.parity.io/sp_state_machine/enum.ExecutionStrategy.html)
+  [Execution Strategy Options](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_state_machine/enum.ExecutionStrategy.html)
 
 - Review the
-  [Runtime Version definition](https://crates.parity.io/sp_version/struct.RuntimeVersion.html).
+  [Runtime Version definition](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_version/struct.RuntimeVersion.html).

--- a/docs/knowledgebase/advanced/storage.md
+++ b/docs/knowledgebase/advanced/storage.md
@@ -46,7 +46,7 @@ each block header. This is used to easily verify the state of the blockchain and
 light clients to verify proofs.
 
 This trie only stores content for the canonical chain, not forks. There is a separate
-[`state_db` layer](https://crates.parity.io/sc_state_db/index.html) that maintains the
+[`state_db` layer](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_state_db/index.html) that maintains the
 trie state with references counted in memory for all that is non-canonical.
 
 ### Child Trie
@@ -77,9 +77,9 @@ reading to learn how to calculate storage keys for the different types of storag
 To calculate the key for a simple [Storage Value](../runtime/storage#Storage-Value), take the
 [TwoX 128 hash](https://github.com/Cyan4973/xxHash) of the name of the module that contains the
 Storage Value and append to it the TwoX 128 hash of the name of the Storage Value itself. For
-example, the [Sudo](https://crates.parity.io/pallet_sudo/index.html) pallet exposes a
+example, the [Sudo](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_sudo/index.html) pallet exposes a
 Storage Value item named
-[`Key`](https://crates.parity.io/pallet_sudo/struct.Module.html#method.key):
+[`Key`](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_sudo/struct.Module.html#method.key):
 
 ```
 twox_128("Sudo")                   = "0x5c0d1176a568c1f92944340dbfed9e9c"
@@ -186,7 +186,7 @@ example, after you remove the first 32 hexadecimal characters that represent the
 
 ## Runtime Storage API
 
-Substrate's [FRAME Support crate](https://crates.parity.io/frame_support/index.html)
+Substrate's [FRAME Support crate](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/index.html)
 provides utilities for generating unique, deterministic keys for your runtime's storage items. These
 storage items are placed in the [state trie](#Trie-Abstraction) and are accessible by
 [querying the trie by key](#Querying-Storage).
@@ -200,4 +200,4 @@ storage items are placed in the [state trie](#Trie-Abstraction) and are accessib
 ### References
 
 - Visit the reference docs for
-  [`paritytech/trie`](https://crates.parity.io/trie_db/trait.Trie.html).
+  [`paritytech/trie`](https://substrate.dev/rustdocs/v2.0.0-rc4/trie_db/trait.Trie.html).

--- a/docs/knowledgebase/integrate/chain-spec.md
+++ b/docs/knowledgebase/integrate/chain-spec.md
@@ -8,7 +8,7 @@ and what consensus-critical state it must have at genesis.
 
 ## Structure of a Chain Spec
 
-The [`ChainSpec` struct](https://crates.parity.io/sc_service/struct.GenericChainSpec.html)
+The [`ChainSpec` struct](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_service/struct.GenericChainSpec.html)
 separates the information contained in a chain spec into two parts. A node can use a `ChainSpec`
 instance to create a genesis block.
 
@@ -147,9 +147,9 @@ After the conversion process, the above snippet looks like this:
 ### Learn More
 
 - Rustdocs for the
-  [`ChainSpec` struct](https://crates.parity.io/sc_service/struct.GenericChainSpec.html)
+  [`ChainSpec` struct](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_service/struct.GenericChainSpec.html)
 - Rustdocs for the
-  [`ProtocolId` struct](https://crates.parity.io/sc_network/config/struct.ProtocolId.html)
+  [`ProtocolId` struct](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_network/config/struct.ProtocolId.html)
 
 ### Examples
 

--- a/docs/knowledgebase/learn-substrate/account-abstractions.md
+++ b/docs/knowledgebase/learn-substrate/account-abstractions.md
@@ -25,13 +25,13 @@ These abstractions are:
   certain validator operations. They should never hold funds.
 
 > **Note:** Learn more about validators and nominators in the context of the Substrate's NPoS
-> [Staking module](https://crates.parity.io/pallet_staking/index.html).
+> [Staking module](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_staking/index.html).
 
 ## Account Keys
 
 A key pair can represent an account and control funds, like normal accounts that you would expect
 from other blockchains. In the context of Substrate's
-[Balances module](https://crates.parity.io/pallet_balances/index.html), these accounts
+[Balances module](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_balances/index.html), these accounts
 must have a minimum amount (an "existential deposit") to exist in storage.
 
 Account keys are defined generically and made concrete in the runtime.
@@ -78,7 +78,7 @@ Controller key. Then, they inform the chain that this key represents their Contr
 publishing the Session certificate in a transaction on the chain.
 
 Substrate provides the
-[Session module](https://crates.parity.io/pallet_session/index.html), which allows
+[Session module](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_session/index.html), which allows
 validators to manage their session keys.
 
 ### Strongly Typed Wrappers
@@ -96,7 +96,7 @@ used for their intended purpose.
 
 If a Session key is compromised, attackers could commit slashable behavior. Session keys should be
 changed regularly (e.g. every session) via
-[the `rotate_keys` RPC](https://crates.parity.io/sc_rpc/author/trait.AuthorApi.html#tymethod.rotate_keys)
+[the `rotate_keys` RPC](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_rpc/author/trait.AuthorApi.html#tymethod.rotate_keys)
 for increased security.
 
 ## Next Steps
@@ -113,11 +113,11 @@ for increased security.
 ### References
 
 - Visit the reference docs for the
-  [session keys runtime API](https://crates.parity.io/sp_session/trait.SessionKeys.html).
+  [session keys runtime API](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_session/trait.SessionKeys.html).
 
 - Take a look at the default
-  [session keys in the Substrate node runtime](https://crates.parity.io/node_runtime/struct.SessionKeys.html).
+  [session keys in the Substrate node runtime](https://substrate.dev/rustdocs/v2.0.0-rc4/node_runtime/struct.SessionKeys.html).
 
 - Take a look at
-  [`substrate_application_crypto`](https://crates.parity.io/sp_application_crypto/index.html),
+  [`substrate_application_crypto`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_application_crypto/index.html),
   used for constructing application specific strongly typed crypto wrappers.

--- a/docs/knowledgebase/learn-substrate/extrinsics.md
+++ b/docs/knowledgebase/learn-substrate/extrinsics.md
@@ -21,7 +21,7 @@ First, it prevents any alterations to the series of extrinsics after the header 
 distributed. Second, it provides a means of allowing light clients to succinctly verify that any
 given extrinsic did indeed exist in a block given only knowledge of the header.
 
-- [Block Reference](https://crates.parity.io/sp_runtime/traits/trait.Block.html)
+- [Block Reference](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/traits/trait.Block.html)
 
 ## Inherents
 
@@ -39,7 +39,7 @@ to prove that a timestamp is true the way the desire to send funds is proved wit
 Rather, validators accept or reject the block based on how reasonable the other validators find the
 timestamp, which may mean it is within some acceptable range of their own system clocks.
 
-- [Inherents Reference](https://crates.parity.io/sp_inherents/index.html)
+- [Inherents Reference](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_inherents/index.html)
 
 ## Signed Transactions
 
@@ -83,11 +83,11 @@ Despite the name, `SignedExtension` can also be used to verify unsigned transact
 `*_unsigned` set of methods can be implemented to encapsulate validation, spam, and replay
 protection logic that is needed by the transaction pool.
 
-- [Signed Extension Reference](https://crates.parity.io/sp_runtime/traits/trait.SignedExtension.html)
+- [Signed Extension Reference](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/traits/trait.SignedExtension.html)
 
 ## Further Reading
 
-- [Reference Documentation](https://crates.parity.io/sp_runtime/traits/trait.Extrinsic.html)
+- [Reference Documentation](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/traits/trait.Extrinsic.html)
 - [Runtime Execution](../runtime/execution)
 - [Transaction Fees](../runtime/fees)
 - [Transaction Pool](../learn-substrate/tx-pool)

--- a/docs/knowledgebase/learn-substrate/session-keys.md
+++ b/docs/knowledgebase/learn-substrate/session-keys.md
@@ -42,7 +42,7 @@ mod app {
 > Refer to the runtime for the most up-to-date implementation.
 
 The default Substrate node implements Session keys in the
-[Session pallet](https://crates.parity.io/pallet_session/index.html).
+[Session pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_session/index.html).
 
 ## Generation and Use
 
@@ -53,5 +53,5 @@ behavior.
 
 Session keys may be changed regularly (e.g. every session) for increased security. Node operators
 can generate them via the RPC call
-[`author_rotateKeys`](https://crates.parity.io/sc_rpc/author/trait.AuthorApi.html#tymethod.rotate_keys).
+[`author_rotateKeys`](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_rpc/author/trait.AuthorApi.html#tymethod.rotate_keys).
 You will then need to register the new keys on chain with a `session.setKeys` transaction.

--- a/docs/knowledgebase/learn-substrate/tx-pool.md
+++ b/docs/knowledgebase/learn-substrate/tx-pool.md
@@ -34,7 +34,7 @@ propagation and block inclusion.
 ## Transaction Dependencies
 
 The `ValidTransaction`
-[struct](https://crates.parity.io/sp_runtime/transaction_validity/struct.ValidTransaction.html)
+[struct](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/transaction_validity/struct.ValidTransaction.html)
 defines the `requires` and `provides` parameters to build a dependency graph of transactions.
 Together with `priority` (discussed below), this dependency graph allows the pool to produce a valid
 linear ordering of transactions.
@@ -55,7 +55,7 @@ dependency (ordering) schemes.
 ## Transaction Priority
 
 Transaction `priority` in the `ValidTransaction`
-[struct](https://crates.parity.io/sp_runtime/transaction_validity/struct.ValidTransaction.html)
+[struct](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/transaction_validity/struct.ValidTransaction.html)
 determines the ordering of transactions that are in the ready queue. If a node is the next block
 author, it will order transactions from high to low priority in the next block until it reaches the
 weight or length limit of the block.

--- a/docs/knowledgebase/learn-substrate/weight.md
+++ b/docs/knowledgebase/learn-substrate/weight.md
@@ -37,7 +37,7 @@ keep up with hardware and software improvements.
 Weights represent the _limited_ time that your blockchain has to validate a block. This includes
 computational cycles, and storage I/O. A custom implementation may use complex structures to express
 this. Substrate weights are simply a
-[numeric value](https://crates.parity.io/frame_support/weights/type.Weight.html).
+[numeric value](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/weights/type.Weight.html).
 
 A weight calculation should always:
 
@@ -81,10 +81,10 @@ execution time depends on, for example, the length of one parameter. It is impor
 calculations do not entail any meaningful work themselves. The pre-dispatch maximum weight should be
 trivially computable from the input arguments with some basic arithmetic.
 
-The [System pallet](https://crates.parity.io/frame_system/struct.Module.html) is
+The [System pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/struct.Module.html) is
 responsible for accumulating the weight of each block as it gets executed and making sure that it
 does not exceed the limit. The
-[Transaction Payment pallet](https://crates.parity.io/pallet_transaction_payment/index.html)
+[Transaction Payment pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_transaction_payment/index.html)
 is responsible for interpreting these weights and deducting fees based upon them. The weighing
 function is part of the runtime so it can be upgraded if needed.
 
@@ -108,13 +108,13 @@ filled with transactions that would take too long to execute. While processing t
 block, the System pallet accumulates both the total length of the block (sum of encoded transactions
 in bytes) and the total weight of the block. If either of these numbers surpass the limits, no
 further transactions are accepted in that block. These limits are defined in
-[`MaximumBlockLength`](https://crates.parity.io/frame_system/trait.Trait.html#associatedtype.MaximumBlockLength)
+[`MaximumBlockLength`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/trait.Trait.html#associatedtype.MaximumBlockLength)
 and
-[`MaximumBlockWeight`](https://crates.parity.io/frame_system/trait.Trait.html#associatedtype.MaximumBlockWeight).
+[`MaximumBlockWeight`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/trait.Trait.html#associatedtype.MaximumBlockWeight).
 
 One important note about these limits is that a portion of them are reserved for the `Operational`
 dispatch class. This rule applies to both of the limits and the ratio can be found in
-[`AvailableBlockRatio`](https://crates.parity.io/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
+[`AvailableBlockRatio`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
 
 For example, if the block length limit is 1 megabyte and the ratio is set to 80%, all transactions
 can fill the first 800 kilobytes of the block while the last 200 can only be filled by the

--- a/docs/knowledgebase/package.json
+++ b/docs/knowledgebase/package.json
@@ -1,9 +1,0 @@
-{
-  "name": "knowledgebase",
-  "version": "1.0.0",
-  "main": "index.js",
-  "license": "Unlicense",
-  "scripts": {
-    "update-doc-versions": "find . -type f -name \"*.md\" -print0 | xargs -0 sed -i -e 's/substrate.dev\\/rustdocs\\/'\"$OLD_VERSION\"'/substrate.dev\\/rustdocs\\/'\"$NEW_VERSION\"'/g'"
-  }
-}

--- a/docs/knowledgebase/package.json
+++ b/docs/knowledgebase/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "knowledgebase",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "Unlicense",
+  "scripts": {
+    "update-doc-versions": "find . -type f -name \"*.md\" -print0 | xargs -0 sed -i -e 's/substrate.dev\\/rustdocs\\/'\"$OLD_VERSION\"'/substrate.dev\\/rustdocs\\/'\"$NEW_VERSION\"'/g'"
+  }
+}

--- a/docs/knowledgebase/runtime/debugging.md
+++ b/docs/knowledgebase/runtime/debugging.md
@@ -10,7 +10,7 @@ are some restrictions when operating inside of a `no_std` environment like the S
 
 To facilitate the debugging of the runtime, Substrate provides extra tools for `Print` debugging (or
 tracing). You can use the
-[`print` function](https://crates.parity.io/sp_runtime/fn.print.html) to log the status
+[`print` function](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/fn.print.html) to log the status
 of the runtime execution.
 
 ```rust
@@ -50,7 +50,7 @@ The values are printed in the terminal or the standard output if the Error gets 
 
 The Printable trait is meant to be a way to print from the runtime in `no_std` and in `std`. The
 `print` function works with any type that implements the
-[`Printable` trait](https://crates.parity.io/sp_runtime/traits/trait.Printable.html).
+[`Printable` trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/traits/trait.Printable.html).
 Substrate implements this trait for some types (`u8`, `u32`, `u64`, `usize`, `&[u8]`, `&str`) by
 default. You can also implement it for your own custom types. Here is an example of implementing it
 for a pallet's `Error` type using the node-template as the example codebase.
@@ -134,7 +134,7 @@ gets called.
 The `print` function works well when you just want to print and you have an implementation of the
 `Printable` trait. In some cases you may want to do more than print, or not bother with
 Substrate-specific traits just for debugging purposes. The
-[`if_std!` macro](https://crates.parity.io/sp_std/macro.if_std.html) is for exactly
+[`if_std!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_std/macro.if_std.html) is for exactly
 this situation.
 
 One caveat of using this macro is that the code inside will only execute when you are actually

--- a/docs/knowledgebase/runtime/events.md
+++ b/docs/knowledgebase/runtime/events.md
@@ -83,7 +83,7 @@ decl_module! {
 ```
 
 The default behavior of this function is to call
-[`deposit_event`](https://crates.parity.io/frame_system/struct.Module.html#method.deposit_event)
+[`deposit_event`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/struct.Module.html#method.deposit_event)
 from the FRAME system, which writes the event to storage.
 
 This function places the event in the System module's runtime storage for that block. At the
@@ -126,6 +126,6 @@ runtime events are used:
 
 ### References
 
-- [`decl_event!` macro](https://crates.parity.io/frame_support/macro.decl_event.html)
-- [`decl_module!` macro](https://crates.parity.io/frame_support/macro.decl_module.html)
-- [`construct_runtime!` macro](https://crates.parity.io/frame_support/macro.construct_runtime.html)
+- [`decl_event!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.decl_event.html)
+- [`decl_module!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.decl_module.html)
+- [`construct_runtime!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.construct_runtime.html)

--- a/docs/knowledgebase/runtime/execution.md
+++ b/docs/knowledgebase/runtime/execution.md
@@ -67,7 +67,7 @@ calculated.
 
 ### References
 
-- [FRAME executive](https://crates.parity.io/frame_executive/index.html)
-- [`decl_event!` macro](https://crates.parity.io/frame_support/macro.decl_event.html)
-- [`decl_storage!` macro](https://crates.parity.io/frame_support/macro.decl_storage.html)
-- [`construct_runtime!` macro](https://crates.parity.io/frame_support/macro.construct_runtime.html)
+- [FRAME executive](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_executive/index.html)
+- [`decl_event!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.decl_event.html)
+- [`decl_storage!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.decl_storage.html)
+- [`construct_runtime!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.construct_runtime.html)

--- a/docs/knowledgebase/runtime/fees.md
+++ b/docs/knowledgebase/runtime/fees.md
@@ -24,15 +24,15 @@ A transaction fee consists of two parts:
 
 - `length_fee`: A per-byte fee that is multiplied by the length, in bytes, of the encoded extrinsic.
   See
-  [`TransactionByteFee`](https://crates.parity.io/pallet_transaction_payment/trait.Trait.html#associatedtype.TransactionByteFee).
+  [`TransactionByteFee`](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_transaction_payment/trait.Trait.html#associatedtype.TransactionByteFee).
 - `weight_fee`: A fee based on the weight of the extrinsic, which is a function of two parameters.
   One, an `ExtrinsicBaseWeight` that is declared in the runtime and applies to all extrinsics. The
   base weight covers inclusion overhead like signature verification. Two, a flexible `#[weight]`
   annotation that accounts for an extrinsic's complexity. In order to convert the weight to
   `Currency`, the runtime must define a
-  [`WeightToFee`](https://crates.parity.io/pallet_transaction_payment/trait.Trait.html#associatedtype.WeightToFee)
+  [`WeightToFee`](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_transaction_payment/trait.Trait.html#associatedtype.WeightToFee)
   struct that implements a conversion function,
-  [`Convert<Weight,Balance>`](https://crates.parity.io/sp_runtime/traits/trait.Convert.html).
+  [`Convert<Weight,Balance>`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/traits/trait.Convert.html).
 
 Based on the above, the final fee of a dispatchable is:
 
@@ -53,13 +53,13 @@ block construction logic perform checks prior to adding an extrinsic to a block.
 
 The above formula gives a fee that is always the same for the same input. However, weight can be
 dynamic and, based on how
-[`WeightToFee`](https://crates.parity.io/pallet_transaction_payment/trait.Trait.html#associatedtype.WeightToFee)
+[`WeightToFee`](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_transaction_payment/trait.Trait.html#associatedtype.WeightToFee)
 is defined, the final fee can include some degree of variability. To fulfill this requirement,
 Substrate provides:
 
-- [`NextFeeMultiplier`](https://crates.parity.io/pallet_transaction_payment/struct.Module.html#method.next_fee_multiplier):
+- [`NextFeeMultiplier`](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_transaction_payment/struct.Module.html#method.next_fee_multiplier):
   A configurable multiplier stored in the Transaction Payment module.
-- [`FeeMultiplierUpdate`](https://crates.parity.io/pallet_transaction_payment/trait.Trait.html#associatedtype.FeeMultiplierUpdate):
+- [`FeeMultiplierUpdate`](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_transaction_payment/trait.Trait.html#associatedtype.FeeMultiplierUpdate):
   A configurable parameter for a runtime to describe how this multiplier can change.
 
 `NextFeeMultiplier` has the type `Fixed64`, which can represent a fixed point number. So, given the
@@ -175,7 +175,7 @@ fn my_dispatchable() {
 
 Dispatches in this class represent normal user-triggered transactions. These types of dispatches may
 only consume a portion of a block's total weight limit; this portion can be found by examining the
-[`AvailableBlockRatio`](https://crates.parity.io/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
+[`AvailableBlockRatio`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
 Normal dispatches are sent to the [transaction pool](../learn-substrate/tx-pool).
 
 #### Operational Dispatches
@@ -183,7 +183,7 @@ Normal dispatches are sent to the [transaction pool](../learn-substrate/tx-pool)
 As opposed to normal dispatches, which represent _usage_ of network capabilities, operational
 dispatches are those that _provide_ network capabilities. These types of dispatches may consume the
 entire weight limit of a block, which is to say that they are not bound by the
-[`AvailableBlockRatio`](https://crates.parity.io/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
+[`AvailableBlockRatio`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
 Dispatches in this class are given maximum priority and are exempt from paying the `length_fee`.
 
 #### Mandatory Dispatches
@@ -385,7 +385,7 @@ payment module drawing inspiration from Transaction Payment.
 
 - Dedicated [weight documentation](../learn-substrate/weight)
 - [Example module](https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs)
-- [SignedExtension](https://crates.parity.io/sp_runtime/traits/trait.SignedExtension.html)
+- [SignedExtension](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/traits/trait.SignedExtension.html)
 
 ### Examples
 

--- a/docs/knowledgebase/runtime/frame.md
+++ b/docs/knowledgebase/runtime/frame.md
@@ -23,7 +23,7 @@ features and functionality for a runtime.
 
 ### System Library
 
-The [System library](https://crates.parity.io/frame_system/index.html) provides
+The [System library](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/index.html) provides
 low-level types, storage, and functions for your blockchain. All other pallets depend on the System
 library as the basis of your Substrate runtime.
 
@@ -50,13 +50,13 @@ the origin of an extrinsic, and more.
 
 ### Executive Module
 
-The [FRAME Executive module](https://crates.parity.io/frame_executive/index.html) acts as the
+The [FRAME Executive module](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_executive/index.html) acts as the
 orchestration layer for the runtime. It dispatches incoming extrinsic calls to the respective
 pallets in the runtime.
 
 ### Support Library
 
-The [FRAME Support library](https://crates.parity.io/frame_support/index.html) is a
+The [FRAME Support library](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/index.html) is a
 collection of Rust macros, types, traits, and functions that simplify the development of Substrate
 pallets.
 
@@ -74,7 +74,7 @@ individual pallets.
 
 Macro for benchmarking a FRAME runtime.
 
-- [Docs](https://crates.parity.io/frame_benchmarking/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_benchmarking/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/benchmarking/src/lib.rs)
 
 ## Prebuilt Pallets
@@ -87,7 +87,7 @@ Let's explore them.
 
 The Assets pallet is a simple, secure module for dealing with fungible assets.
 
-- [Docs](https://crates.parity.io/pallet_assets/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_assets/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/assets/src/lib.rs)
 
 ### Atomic Swap
@@ -96,14 +96,14 @@ A module for atomically sending funds from an origin to a target. A proof is use
 target to approve (claim) the swap. If the swap is not claimed within a specified duration of time,
 the sender may cancel it.
 
-- [Docs](https://crates.parity.io/pallet_atomic_swap/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_atomic_swap/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/atomic-swap/src/lib.rs)
 
 ### Aura
 
 The Aura pallet extends Aura consensus by managing offline reporting.
 
-- [Docs](https://crates.parity.io/pallet_aura/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_aura/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/aura/src/lib.rs)
 
 ### Authority Discovery
@@ -112,14 +112,14 @@ The Authority Discovery pallet is used by `core/authority-discovery` to retrieve
 authorities, learn its own authority ID, as well as to sign and verify messages to and from other
 authorities.
 
-- [Docs](https://crates.parity.io/pallet_authority_discovery/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_authority_discovery/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/authority-discovery/src/lib.rs)
 
 ### Authorship
 
 The Authorship pallet tracks the current author of the block and recent uncles.
 
-- [Docs](https://crates.parity.io/pallet_authorship/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_authorship/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/authorship/src/lib.rs)
 
 ### BABE
@@ -127,14 +127,14 @@ The Authorship pallet tracks the current author of the block and recent uncles.
 The BABE pallet extends BABE consensus by collecting on-chain randomness from VRF outputs and
 managing epoch transitions.
 
-- [Docs](https://crates.parity.io/pallet_babe/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_babe/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/babe/src/lib.rs)
 
 ### Balances
 
 The Balances pallet provides functionality for handling accounts and balances.
 
-- [Docs](https://crates.parity.io/pallet_balances/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_balances/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/balances/src/lib.rs)
 
 ### Benchmark
@@ -142,7 +142,7 @@ The Balances pallet provides functionality for handling accounts and balances.
 A pallet that contains common runtime patterns in an isolated manner. This pallet is not meant to be
 used in a production blockchain, just for benchmarking and testing purposes.
 
-- [Docs](https://crates.parity.io/pallet_benchmark/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_benchmark/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/benchmark/src/lib.rs)
 
 ### Collective
@@ -150,7 +150,7 @@ used in a production blockchain, just for benchmarking and testing purposes.
 The Collective pallet allows a set of account IDs to make their collective feelings known through
 dispatched calls from specialized origins.
 
-- [Docs](https://crates.parity.io/pallet_collective/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_collective/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/collective/src/lib.rs)
 
 ### Contracts
@@ -158,7 +158,7 @@ dispatched calls from specialized origins.
 The Contracts pallet provides functionality for the runtime to deploy and execute WebAssembly
 smart-contracts.
 
-- [Docs](https://crates.parity.io/pallet_contracts/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_contracts/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/contracts/src/lib.rs)
 
 ### Democracy
@@ -166,7 +166,7 @@ smart-contracts.
 The Democracy pallet provides a democratic system that handles administration of general stakeholder
 voting.
 
-- [Docs](https://crates.parity.io/pallet_democracy/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_democracy/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/democracy/src/lib.rs)
 
 ### Elections Phragmen
@@ -174,14 +174,14 @@ voting.
 The Phragmen Elections pallet is an election module based on
 [sequential phragmen](https://research.web3.foundation/en/latest/polkadot/NPoS/4.%20Sequential%20Phragm%C3%A9n%E2%80%99s%20method.html).
 
-- [Docs](https://crates.parity.io/pallet_elections_phragmen/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_elections_phragmen/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/elections-phragmen/src/lib.rs)
 
 ### Elections
 
 The Elections pallet is an election module for stake-weighted membership selection of a collective.
 
-- [Docs](https://crates.parity.io/pallet_elections/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_elections/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/elections/src/lib.rs)
 
 ### EVM
@@ -189,7 +189,7 @@ The Elections pallet is an election module for stake-weighted membership selecti
 The EVM pallet is an [Ethereum](https://en.wikipedia.org/wiki/Ethereum) virtual machine (EVM)
 execution module for Substrate.
 
-- [Docs](https://crates.parity.io/pallet_evm/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_evm/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/evm/src/lib.rs)
 
 ### Example Offchain Worker
@@ -197,7 +197,7 @@ execution module for Substrate.
 The Offchain Worker Example: A simple pallet demonstrating concepts, APIs and structures common to
 most offchain workers.
 
-- [Docs](https://crates.parity.io/pallet_example_offchain_worker/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_example_offchain_worker/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/example-offchain-worker/src/lib.rs)
 
 ### Example
@@ -205,21 +205,21 @@ most offchain workers.
 The Example pallet is a simple example of a pallet demonstrating concepts, APIs, and structures
 common to most pallets.
 
-- [Docs](https://crates.parity.io/pallet_example/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_example/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs)
 
 ### Finality Tracker
 
 The Finality Tracker pallet tracks the last finalized block, as perceived by block authors.
 
-- [Docs](https://crates.parity.io/pallet_finality_tracker/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_finality_tracker/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/finality-tracker/src/lib.rs)
 
 ### Generic Asset
 
 The Generic Asset pallet provides functionality for handling accounts and asset balances.
 
-- [Docs](https://crates.parity.io/pallet_generic_asset/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_generic_asset/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/generic-asset/src/lib.rs)
 
 ### GRANDPA
@@ -227,7 +227,7 @@ The Generic Asset pallet provides functionality for handling accounts and asset 
 The GRANDPA pallet extends GRANDPA consensus by managing the GRANDPA authority set ready for the
 native code.
 
-- [Docs](https://crates.parity.io/pallet_grandpa/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_grandpa/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/grandpa/src/lib.rs)
 
 ### Identity
@@ -237,7 +237,7 @@ Registrars can set a fee to provide identity-verification service. Anyone can pu
 identity for a fixed deposit and ask for review by any number of registrars (paying each of their
 fees). Registrar judgements are given as an enum, allowing for sophisticated, multi-tier opinions.
 
-- [Docs](https://crates.parity.io/pallet_identity/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_identity/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/identity/src/lib.rs)
 
 ### I'm Online
@@ -245,7 +245,7 @@ fees). Registrar judgements are given as an enum, allowing for sophisticated, mu
 The I'm Online pallet allows validators to gossip a heartbeat transaction with each new session to
 signal that the node is online.
 
-- [Docs](https://crates.parity.io/pallet_im_online/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_im_online/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/im-online/src/lib.rs)
 
 ### Indices
@@ -253,7 +253,7 @@ signal that the node is online.
 The Indices pallet allocates indices for newly created accounts. An index is a short form of an
 address.
 
-- [Docs](https://crates.parity.io/pallet_indices/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_indices/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/indices/src/lib.rs)
 
 ### Membership
@@ -261,14 +261,14 @@ address.
 The Membership pallet allows control of membership of a set of `AccountId`s, useful for managing
 membership of a collective.
 
-- [Docs](https://crates.parity.io/pallet_membership/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_membership/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/membership/src/lib.rs)
 
 ### Multisig
 
 A module for doing multi-signature dispatches.
 
-- [Docs](https://crates.parity.io/pallet_multisig/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_multisig/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/multisig/src/lib.rs)
 
 ### Nicks
@@ -276,14 +276,14 @@ A module for doing multi-signature dispatches.
 Nicks is a trivial module for keeping track of account names on-chain. It makes no effort to create
 a name hierarchy, be a DNS replacement or provide reverse lookups.
 
-- [Docs](https://crates.parity.io/pallet_nicks/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_nicks/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/nicks/src/lib.rs)
 
 ### Offences
 
 The Offences pallet tracks reported offences.
 
-- [Docs](https://crates.parity.io/pallet_offences/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_offences/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/offences/src/lib.rs)
 
 ### Proxy
@@ -291,7 +291,7 @@ The Offences pallet tracks reported offences.
 A module allowing accounts to give permission to other accounts to dispatch types of calls from
 their signed origin.
 
-- [Docs](https://crates.parity.io/pallet_proxy/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_proxy/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/proxy/src/lib.rs)
 
 ### Randomness Collective Flip
@@ -300,7 +300,7 @@ The Randomness Collective Flip pallet provides a `random` function that can be u
 generates low-influence random values based on the block hashes from the previous `81` blocks. This
 pallet is not intended for use in production.
 
-- [Docs](https://crates.parity.io/pallet_randomness_collective_flip/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_randomness_collective_flip/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/randomness-collective-flip/src/lib.rs)
 
 ### Recovery
@@ -311,7 +311,7 @@ make calls on-behalf-of another account which they have recovered. The recovery 
 by trusted "friends" whom the original account owner chooses. A threshold (M) out of N friends are
 needed to give another account access to the recoverable account.
 
-- [Docs](https://crates.parity.io/pallet_recovery/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_recovery/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/recovery/src/lib.rs)
 
 ### Scheduler
@@ -319,7 +319,7 @@ needed to give another account access to the recoverable account.
 This module exposes capabilities for scheduling dispatches to occur at a specified block number or
 at a specified period. These scheduled dispatches may be named or anonymous and may be canceled.
 
-- [Docs](https://crates.parity.io/pallet_scheduler/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_scheduler/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/scheduler/src/lib.rs)
 
 ### Scored Pool
@@ -327,7 +327,7 @@ at a specified period. These scheduled dispatches may be named or anonymous and 
 The Scored Pool pallet maintains a scored membership pool where the highest scoring entities are
 made members.
 
-- [Docs](https://crates.parity.io/pallet_scored_pool/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_scored_pool/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/scored-pool/src/lib.rs)
 
 ### Session
@@ -335,7 +335,7 @@ made members.
 The Session pallet allows validators to manage their session keys, provides a function for changing
 the session length, and handles session rotation.
 
-- [Docs](https://crates.parity.io/pallet_session/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_session/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/session/src/lib.rs)
 
 ### Society
@@ -343,14 +343,14 @@ the session length, and handles session rotation.
 The Society module is an economic game which incentivizes users to participate and maintain a
 membership society.
 
-- [Docs](https://crates.parity.io/pallet_society/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_society/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/society/src/lib.rs)
 
 ### Staking
 
 The Staking pallet is used to manage funds at stake by network maintainers.
 
-- [Docs](https://crates.parity.io/pallet_staking/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_staking/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/staking/src/lib.rs)
 
 ### Sudo
@@ -358,21 +358,21 @@ The Staking pallet is used to manage funds at stake by network maintainers.
 The Sudo pallet allows for a single account (called the "sudo key") to execute dispatchable
 functions that require a `Root` origin or designate a new account to replace them as the sudo key.
 
-- [Docs](https://crates.parity.io/pallet_sudo/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_sudo/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/sudo/src/lib.rs)
 
 ### Timestamp
 
 The Timestamp pallet provides functionality to get and set the on-chain time.
 
-- [Docs](https://crates.parity.io/pallet_timestamp/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_timestamp/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/timestamp/src/lib.rs)
 
 ### Transaction Payment
 
 The Transaction Payment pallet provides the basic logic to compute pre-dispatch transaction fees.
 
-- [Docs](https://crates.parity.io/pallet_transaction_payment/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_transaction_payment/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/transaction-payment/src/lib.rs)
 
 ### Treasury
@@ -380,14 +380,14 @@ The Transaction Payment pallet provides the basic logic to compute pre-dispatch 
 The Treasury pallet provides a "pot" of funds that can be managed by stakeholders in the system and
 a structure for making spending proposals from this pot.
 
-- [Docs](https://crates.parity.io/pallet_treasury/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_treasury/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/treasury/src/lib.rs)
 
 ### Utility
 
 A stateless module with helpers for dispatch management.
 
-- [Docs](https://crates.parity.io/pallet_utility/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_utility/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/utility/src/lib.rs)
 
 ### Vesting
@@ -396,7 +396,7 @@ A simple module providing a means of placing a linear curve on an account's lock
 module ensures that there is a lock in place preventing the balance to drop below the unvested
 amount for any reason other than transaction fee payment.
 
-- [Docs](https://crates.parity.io/pallet_vesting/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_vesting/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/vesting/src/lib.rs)
 
 ## Next Steps
@@ -413,10 +413,10 @@ amount for any reason other than transaction fee payment.
 ### References
 
 - Visit the reference docs for the
-  [System library](https://crates.parity.io/frame_system/index.html).
+  [System library](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/index.html).
 
 - Visit the reference docs for the
-  [Executive pallet](https://crates.parity.io/frame_executive/index.html).
+  [Executive pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_executive/index.html).
 
 - Visit the reference docs for the
-  [FRAME support library](https://crates.parity.io/frame_support/index.html).
+  [FRAME support library](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/index.html).

--- a/docs/knowledgebase/runtime/index.md
+++ b/docs/knowledgebase/runtime/index.md
@@ -20,7 +20,7 @@ by implementing the traits in _primitives._
 ![Runtime Composition](assets/runtime.png)
 
 For example, if you want to add smart contract functionality to your blockchain, you simply need to
-include the [Contracts](https://crates.parity.io/pallet_contracts/index.html) pallet.
+include the [Contracts](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_contracts/index.html) pallet.
 Adding this pallet will expose the smart contract interface so that users can deploy smart contracts
 that execute in Wasm.
 

--- a/docs/knowledgebase/runtime/macros.md
+++ b/docs/knowledgebase/runtime/macros.md
@@ -53,7 +53,7 @@ View our most [simple Substrate runtime](index) to see all these macros interact
 
 ### References
 
-- [`decl_module!` macro](https://crates.parity.io/frame_support/macro.decl_module.html)
-- [`decl_event!` macro](https://crates.parity.io/frame_support/macro.decl_event.html)
-- [`decl_storage!` macro](https://crates.parity.io/frame_support/macro.decl_storage.html)
-- [`construct_runtime!` macro](https://crates.parity.io/frame_support/macro.construct_runtime.html)
+- [`decl_module!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.decl_module.html)
+- [`decl_event!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.decl_event.html)
+- [`decl_storage!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.decl_storage.html)
+- [`construct_runtime!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.construct_runtime.html)

--- a/docs/knowledgebase/runtime/metadata.md
+++ b/docs/knowledgebase/runtime/metadata.md
@@ -27,8 +27,8 @@ Substrate node, as well as language-agnostic HTTP and WebSocket APIs.
 
 The easiest way to get the metadata is by querying the automatically-generated JSON-RPC function
 `state_getMetadata`. This will return a vector of SCALE-encoded bytes. You can decode this using the
-[`frame-metadata`](https://crates.parity.io/frame_metadata/index.html) and
-[`parity-scale-codec`](https://crates.parity.io/parity_scale_codec/index.html) libraries.
+[`frame-metadata`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_metadata/index.html) and
+[`parity-scale-codec`](https://substrate.dev/rustdocs/v2.0.0-rc4/parity_scale_codec/index.html) libraries.
 
 Some helpful libraries like [`substrate-subxt`](https://github.com/paritytech/substrate-subxt) fetch
 the metadata and decode them for you. Once decoded, the structure may be serialized into JSON with
@@ -54,9 +54,9 @@ console.log("Metadata: " + metadata.raw);
 
 ### HTTP & WebSocket APIs
 
-Substrate nodes expose [a JSON-RPC API](https://crates.parity.io/sc_rpc/index.html) that you can
+Substrate nodes expose [a JSON-RPC API](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_rpc/index.html) that you can
 access by way of **HTTP** or **WebSocket** requests. The message to
-[request metadata](https://crates.parity.io/sc_rpc/state/struct.StateClient.html#method.metadata)
+[request metadata](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_rpc/state/struct.StateClient.html#method.metadata)
 from a node looks like this:
 
 ```json
@@ -110,7 +110,7 @@ The hex blob that is returned by the JSON-RPCs `state_getMetadata` method starts
 magic number, `0x6d657461`, which represents "meta" in plain text. The next piece of data (`0x0b` in
 the example above) represents the metadata version; decoding the hexadecimal value `0x0b` yields the
 decimal value 11, which is
-[the version of the Substrate metadata format](https://crates.parity.io/frame_metadata/enum.RuntimeMetadata.html)
+[the version of the Substrate metadata format](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_metadata/enum.RuntimeMetadata.html)
 that the result encodes. After the metadata version, the next piece of information encoded in the
 result field is the number of pallets that inform the blockchain's runtime; in the example above,
 the hexadecimal value `0x7c` represents the decimal number 31, which is SCALE-encoded by taking its
@@ -118,9 +118,9 @@ binary representation (`11111` or `0x1F` in hex), shifting it two bits to the le
 encoding that as hex.
 
 The remaining blob encodes
-[the metadata of each pallet](https://crates.parity.io/frame_metadata/struct.ModuleMetadata.html),
+[the metadata of each pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_metadata/struct.ModuleMetadata.html),
 which will be reviewed below as well as some
-[extrinsic metadata](https://crates.parity.io/frame_metadata/struct.ExtrinsicMetadata.html), which
+[extrinsic metadata](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_metadata/struct.ExtrinsicMetadata.html), which
 is mostly out of the scope of this document.
 
 ## Decoded Metadata Format
@@ -248,7 +248,7 @@ decl_storage! {
 ```
 
 Storage metadata provides blockchain clients with the information that is required to query
-[the JSON-RPC's storage function](https://crates.parity.io/sc_rpc/state/struct.StateClient.html#method.storage)
+[the JSON-RPC's storage function](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_rpc/state/struct.StateClient.html#method.storage)
 to get information for a specific storage item.
 
 ##### Calls
@@ -442,7 +442,7 @@ This will expose the following metadata:
 
 These are errors that could occur during the submission or execution of an extrinsic. In this case,
 the FRAME System pallet is declaring that it may raise the
-[the `InvalidSpecName` error](https://crates.parity.io/frame_system/enum.Error.html#variant.InvalidSpecName).
+[the `InvalidSpecName` error](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/enum.Error.html#variant.InvalidSpecName).
 
 ## Next Steps
 
@@ -460,4 +460,4 @@ the FRAME System pallet is declaring that it may raise the
 
 ### References
 
-- [Metadata](https://crates.parity.io/frame_metadata/index.html)
+- [Metadata](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_metadata/index.html)

--- a/docs/knowledgebase/runtime/origin.md
+++ b/docs/knowledgebase/runtime/origin.md
@@ -47,7 +47,7 @@ proposal.dispatch(system::RawOrigin::None.into())
 ```
 
 You can look at the source code of the
-[Sudo module](https://crates.parity.io/pallet_sudo/index.html) for a practical
+[Sudo module](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_sudo/index.html) for a practical
 implementation of this.
 
 ## Next Steps
@@ -71,4 +71,4 @@ implementation of this.
 ### References
 
 - Visit the reference docs for the
-  [`RawOrigin` enum](https://crates.parity.io/frame_system/enum.RawOrigin.html).
+  [`RawOrigin` enum](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_system/enum.RawOrigin.html).

--- a/docs/knowledgebase/runtime/primitives.md
+++ b/docs/knowledgebase/runtime/primitives.md
@@ -72,7 +72,7 @@ FRAME:
 ### References
 
 - View the
-  [primitive types defined in `node-primitives`](https://crates.parity.io/node_primitives/index.html).
+  [primitive types defined in `node-primitives`](https://substrate.dev/rustdocs/v2.0.0-rc4/node_primitives/index.html).
 
 - View the
-  [`traits` defined in `sp-runtime`](https://crates.parity.io/sp_runtime/traits/index.html)
+  [`traits` defined in `sp-runtime`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/traits/index.html)

--- a/docs/knowledgebase/runtime/storage.md
+++ b/docs/knowledgebase/runtime/storage.md
@@ -16,15 +16,15 @@ information about how these interfaces are implemented.
 
 ## Storage Items
 
-The `storage` module in [FRAME Support](https://crates.parity.io/frame_support/storage/index.html)
+The `storage` module in [FRAME Support](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/index.html)
 gives runtime developers access to Substrate's flexible storage APIs. Any value that can be encoded
 by the [Parity SCALE codec](../advanced/codec) is supported by these storage APIs:
 
-- [Storage Value](https://crates.parity.io/frame_support/storage/trait.StorageValue.html) - A single
+- [Storage Value](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageValue.html) - A single
   value
-- [Storage Map](https://crates.parity.io/frame_support/storage/trait.StorageMap.html) - A key-value
+- [Storage Map](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageMap.html) - A key-value
   hash map
-- [Storage Double Map](https://crates.parity.io/frame_support/storage/trait.StorageDoubleMap.html) -
+- [Storage Double Map](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageDoubleMap.html) -
   An implementation of a map with two keys that provides the important ability to efficiently remove
   all entries that have a common first key
 
@@ -46,16 +46,16 @@ will stop producing blocks, which means that it will stop functioning.
 #### Methods
 
 Refer to the Storage Value documentation for
-[a comprehensive list of the methods that Storage Values expose](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#required-methods).
+[a comprehensive list of the methods that Storage Values expose](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageValue.html#required-methods).
 Some of the most important methods are summarized here:
 
-- [`get()`](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.get) -
+- [`get()`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageValue.html#tymethod.get) -
   Load the value from storage.
-- [`put(val)`](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.put) -
+- [`put(val)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageValue.html#tymethod.put) -
   Store the provided value.
-- [`mutate(fn)`](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.mutate) -
+- [`mutate(fn)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageValue.html#tymethod.mutate) -
   Mutate the value with the provided function.
-- [`take()`](https://crates.parity.io/frame_support/storage/trait.StorageValue.html#tymethod.take) -
+- [`take()`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageValue.html#tymethod.take) -
   Load the value and remove it from storage.
 
 ### Storage Maps
@@ -70,21 +70,21 @@ Storage Maps are implemented.
 
 #### Methods
 
-[Storage Maps expose an API](https://crates.parity.io/frame_support/storage/trait.StorageMap.html#required-methods)
+[Storage Maps expose an API](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageMap.html#required-methods)
 that is similar to that of Storage Values.
 
 - `get` - Load the value associated with the provided key from storage. Docs:
-  [`StorageMap#get(key)`](https://crates.parity.io/frame_support/storage/trait.StorageMap.html#tymethod.get),
-  [`StorageDoubleMap#get(key1, key2)`](https://crates.parity.io/frame_support/storage/trait.StorageDoubleMap.html#tymethod.get)
+  [`StorageMap#get(key)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageMap.html#tymethod.get),
+  [`StorageDoubleMap#get(key1, key2)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageDoubleMap.html#tymethod.get)
 - `insert` - Store the provided value by associating it with the given key. Docs:
-  [`StorageMap#insert(key, val)`](https://crates.parity.io/frame_support/storage/trait.StorageMap.html#tymethod.insert),
-  [`StorageDoubleMap#insert(key1, key2, val)`](https://crates.parity.io/frame_support/storage/trait.StorageDoubleMap.html#tymethod.insert)
+  [`StorageMap#insert(key, val)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageMap.html#tymethod.insert),
+  [`StorageDoubleMap#insert(key1, key2, val)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageDoubleMap.html#tymethod.insert)
 - `mutate` - Use the provided function to mutate the value associated with the given key. Docs:
-  [`StorageMap#mutate(key, fn)`](https://crates.parity.io/frame_support/storage/trait.StorageMap.html#tymethod.mutate),
-  [`StorageDoubleMap#mutate(key1, key2, fn)`](https://crates.parity.io/frame_support/storage/trait.StorageDoubleMap.html#tymethod.mutate)
+  [`StorageMap#mutate(key, fn)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageMap.html#tymethod.mutate),
+  [`StorageDoubleMap#mutate(key1, key2, fn)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageDoubleMap.html#tymethod.mutate)
 - `take` - Load the value associated with the given key and remove it from storage. Docs:
-  [`StorageMap#take(key)`](https://crates.parity.io/frame_support/storage/trait.StorageMap.html#tymethod.take),
-  [`StorageDoubleMap#take(key1, key2)`](https://crates.parity.io/frame_support/storage/trait.StorageDoubleMap.html#tymethod.take)
+  [`StorageMap#take(key)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageMap.html#tymethod.take),
+  [`StorageDoubleMap#take(key1, key2)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageDoubleMap.html#tymethod.take)
 
 #### Iterable Storage Maps
 
@@ -107,16 +107,16 @@ Storage Double Maps, the `iter` and `drain` methods require a parameter, i.e. th
 
 - `iter` - Enumerate all elements in the map in no particular order. If you alter the map while
   doing this, you'll get undefined results. Docs:
-  [`IterableStorageMap#iter()`](https://crates.parity.io/frame_support/storage/trait.IterableStorageMap.html#tymethod.iter),
-  [`IterableStorageDoubleMap#iter(key1)`](https://crates.parity.io/frame_support/storage/trait.IterableStorageDoubleMap.html#tymethod.iter)
+  [`IterableStorageMap#iter()`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.IterableStorageMap.html#tymethod.iter),
+  [`IterableStorageDoubleMap#iter(key1)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.IterableStorageDoubleMap.html#tymethod.iter)
 - `drain` - Remove all elements from the map and iterate through them in no particular order. If you
   add elements to the map while doing this, you'll get undefined results. Docs:
-  [`IterableStorageMap#drain()`](https://crates.parity.io/frame_support/storage/trait.IterableStorageMap.html#tymethod.drain),
-  [`IterableStorageDoubleMap#drain(key1)`](https://crates.parity.io/frame_support/storage/trait.IterableStorageDoubleMap.html#tymethod.drain)
+  [`IterableStorageMap#drain()`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.IterableStorageMap.html#tymethod.drain),
+  [`IterableStorageDoubleMap#drain(key1)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.IterableStorageDoubleMap.html#tymethod.drain)
 - `translate` - Use the provided function to translate all elements of the map, in no particular
   order. To remove an element from the map, return `None` from the translation function. Docs:
-  [`IterableStorageMap#translate(fn)`](https://crates.parity.io/frame_support/storage/trait.IterableStorageMap.html#tymethod.translate),
-  [`IterableStorageDoubleMap#translate(fn)`](https://crates.parity.io/frame_support/storage/trait.IterableStorageDoubleMap.html#tymethod.translate)
+  [`IterableStorageMap#translate(fn)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.IterableStorageMap.html#tymethod.translate),
+  [`IterableStorageDoubleMap#translate(fn)`](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.IterableStorageDoubleMap.html#tymethod.translate)
 
 #### Hashing Algorithms
 
@@ -164,11 +164,11 @@ those that are transparent:
 
 | Hasher                                                                                     | Cryptographic | Transparent |
 | ------------------------------------------------------------------------------------------ | ------------- | ----------- |
-| [Blake2 128 Concat](https://crates.parity.io/frame_support/struct.Blake2_128Concat.html)   | X             | X           |
-| [TwoX 64 Concat](https://crates.parity.io/frame_support/struct.Twox64Concat.html)          |               | X           |
-| [Identity](https://crates.parity.io/frame_support/struct.Identity.html)                    |               |             |
-| [Blake2 128](https://crates.parity.io/frame_support/struct.Blake2_128.html) **DEPRECATED** | X             |             |
-| [TwoX 128](https://crates.parity.io/frame_support/struct.Twox128.html) **DEPRECATED**      |               |             |
+| [Blake2 128 Concat](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/struct.Blake2_128Concat.html)   | X             | X           |
+| [TwoX 64 Concat](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/struct.Twox64Concat.html)          |               | X           |
+| [Identity](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/struct.Identity.html)                    |               |             |
+| [Blake2 128](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/struct.Blake2_128.html) **DEPRECATED** | X             |             |
+| [TwoX 128](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/struct.Twox128.html) **DEPRECATED**      |               |             |
 
 The Identity hasher encapsulates a hashing algorithm that has an output equal to its input (the
 identity function). This type of hasher should only be used when the starting key is already a
@@ -177,7 +177,7 @@ cryptographic hash.
 ## Declaring Storage Items
 
 You can use
-[the `decl_storage` macro](https://crates.parity.io/frame_support/macro.decl_storage.html) to easily
+[the `decl_storage` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.decl_storage.html) to easily
 create new runtime storage items. Here is an example of what it looks like to declare each type of
 storage item:
 
@@ -251,20 +251,20 @@ Substrate's runtime storage APIs include capabilities to initialize storage item
 block of your blockchain. The genesis storage configuration APIs expose a number of mechanisms for
 initializing storage, all of which have entry points in the `decl_storage` macro. These mechanisms
 all result in the creation of a `GenesisConfig` data type that implements
-[the `BuildModuleGenesisStorage` trait](https://crates.parity.io/sp_runtime/trait.BuildModuleGenesisStorage.html)
+[the `BuildModuleGenesisStorage` trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/trait.BuildModuleGenesisStorage.html)
 and will be added to the module that contains the storage items (e.g.
-[`Struct pallet_balances::GenesisConfig`](https://crates.parity.io/pallet_balances/struct.GenesisConfig.html));
+[`Struct pallet_balances::GenesisConfig`](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_balances/struct.GenesisConfig.html));
 storage items that are tagged for genesis configuration will have a corresponding attribute on this
 data type. In order to consume a module's genesis configuration capabilities, you must include the
 `Config` element when adding the module to your runtime with
-[the `construct_runtime` macro](https://crates.parity.io/frame_support/macro.construct_runtime.html).
+[the `construct_runtime` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.construct_runtime.html).
 All the `GenesisConfig` types for the modules that inform a runtime will be aggregated into a single
 `GenesisConfig` type for that runtime, which implements
-[the `BuildStorage` trait](https://crates.parity.io/sp_runtime/trait.BuildStorage.html) (e.g.
-[`Struct node_template_runtime::GenesisConfig`](https://crates.parity.io/node_template_runtime/struct.GenesisConfig.html));
+[the `BuildStorage` trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_runtime/trait.BuildStorage.html) (e.g.
+[`Struct node_template_runtime::GenesisConfig`](https://substrate.dev/rustdocs/v2.0.0-rc4/node_template_runtime/struct.GenesisConfig.html));
 each attribute on this type corresponds to a `GenesisConfig` from one of the runtime's modules.
 Ultimately, the runtime's `GenesisConfig` is exposed by way of
-[the `ChainSpec` trait](https://crates.parity.io/sc_chain_spec/trait.ChainSpec.html). For a complete
+[the `ChainSpec` trait](https://substrate.dev/rustdocs/v2.0.0-rc4/sc_chain_spec/trait.ChainSpec.html). For a complete
 and concrete example of using Substrate's genesis storage configuration capabilities, refer to the
 `decl_storage` macro in
 [the Society pallet](https://github.com/paritytech/substrate/blob/master/frame/society/src/lib.rs)
@@ -418,7 +418,7 @@ Remember, the fundamental principle of blockchain runtime storage is to minimize
 _consensus-critical_ data should be stored in your runtime. When possible, use techniques like
 hashing to reduce the amount of data you must store. For instance, many of Substrate's governance
 capabilities (e.g.
-[the Democracy pallet's `propose` dispatchable](https://crates.parity.io/pallet_democracy/enum.Call.html#variant.propose))
+[the Democracy pallet's `propose` dispatchable](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_democracy/enum.Call.html#variant.propose))
 allow network participants to vote on the _hash_ of a dispatchable call, which is always bounded in
 size, as opposed to the call itself, which may be unbounded in length. This is especially true in
 the case of runtime upgrades where the dispatchable call takes an entire runtime Wasm blob as its
@@ -457,7 +457,7 @@ Do not use runtime storage to store intermediate or transient data within the co
 operation that is logically atomic or data that will not be needed if the operation is to fail. This
 does not mean that runtime storage should not be used to track the state of ongoing actions that
 require multiple atomic operations, as in the case of
-[the multi-signature capabilities from the Utility pallet](https://crates.parity.io/pallet_utility/enum.Call.html#variant.as_multi).
+[the multi-signature capabilities from the Utility pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_utility/enum.Call.html#variant.as_multi).
 In this case, runtime storage is used to track the signatories on a dispatchable call even though a
 given call may never receive enough signatures to actually be invoked. In this case, each signature
 is considered an atomic event in the ongoing multi-signature operation; the data needed to record a
@@ -469,7 +469,7 @@ been met.
 Creating bounds on the size of storage items is an extremely effective way to control the use of
 runtime storage and one that is used repeatedly throughout the Substrate codebase. In general, any
 storage item whose size is determined by user action should have a bound on it.
-[The multi-signature capabilities from the Utility pallet](https://crates.parity.io/pallet_utility/trait.Trait.html#associatedtype.MaxSignatories)
+[The multi-signature capabilities from the Utility pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_utility/trait.Trait.html#associatedtype.MaxSignatories)
 that were described above are one such example. In this case, the list of signatories associated
 with a multi-signature operation is provided by the multi-signature participants. Because this
 signatory list is [necessary to come to consensus](#What-to-Store) on the state of the
@@ -492,10 +492,10 @@ Check out
 ### References
 
 - Visit the reference docs for the
-  [`decl_storage!` macro](https://crates.parity.io/frame_support/macro.decl_storage.html) for more
+  [`decl_storage!` macro](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/macro.decl_storage.html) for more
   details about the available storage declarations.
 - Visit the reference docs for
-  [StorageValue](https://crates.parity.io/frame_support/storage/trait.StorageValue.html),
-  [StorageMap](https://crates.parity.io/frame_support/storage/trait.StorageMap.html) and
-  [StorageDoubleMap](https://crates.parity.io/frame_support/storage/trait.StorageDoubleMap.html) to
+  [StorageValue](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageValue.html),
+  [StorageMap](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageMap.html) and
+  [StorageDoubleMap](https://substrate.dev/rustdocs/v2.0.0-rc4/frame_support/storage/trait.StorageDoubleMap.html) to
   learn more about their APIs.

--- a/docs/knowledgebase/runtime/tests.md
+++ b/docs/knowledgebase/runtime/tests.md
@@ -41,17 +41,17 @@ requires tracking a `(AccountId: u64, Balance: u64)` mapping.
 
 ### Mock Runtime Storage
 
-The [`runtime-io`](https://crates.parity.io/sp_io/index.html) crate exposes a
-[`TestExternalities`](https://crates.parity.io/sp_io/type.TestExternalities.html)
+The [`runtime-io`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_io/index.html) crate exposes a
+[`TestExternalities`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_io/type.TestExternalities.html)
 implementation frequently used for mocking storage in tests. It is the type alias for an in-memory,
 hashmap-based externalities implementation in
-[`substrate_state_machine`](https://crates.parity.io/sp_state_machine/index.html)]
+[`substrate_state_machine`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_state_machine/index.html)]
 referred to as
-[`TestExternalities`](https://crates.parity.io/sp_state_machine/struct.TestExternalities.html).
+[`TestExternalities`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_state_machine/struct.TestExternalities.html).
 
 In the [basic mock runtime's recipe](https://substrate.dev/recipes/3-entrees/testing/mock.html), an
 `ExtBuilder` object is defined to build an instance of
-[`TestExternalities`](https://crates.parity.io/sp_io/type.TestExternalities.html).
+[`TestExternalities`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_io/type.TestExternalities.html).
 
 ```rust
 pub struct ExtBuilder;
@@ -66,7 +66,7 @@ impl ExtBuilder {
 
 To create the test environment in unit tests, the build method is called to generate a
 `TestExternalities` using the default genesis configuration. Then,
-[`with_externalities`](https://crates.parity.io/sp_externalities/fn.with_externalities.html)
+[`with_externalities`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_externalities/fn.with_externalities.html)
 provides the runtime environment in which we may call the pallet's methods to test that storage,
 events, and errors behave as expected.
 
@@ -80,12 +80,12 @@ fn fake_test_example() {
 ```
 
 Custom implementations of
-[Externalities](https://crates.parity.io/sp_externalities/index.html) allow developers
+[Externalities](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_externalities/index.html) allow developers
 to construct runtime environments that provide access to features of the outer node. Another example
 of this can be found in
-[`offchain`](https://crates.parity.io/sp_core/offchain/index.html), which maintains its
+[`offchain`](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_core/offchain/index.html), which maintains its
 own
-[Externalities](https://crates.parity.io/sp_core/offchain/trait.Externalities.html)
+[Externalities](https://substrate.dev/rustdocs/v2.0.0-rc4/sp_core/offchain/trait.Externalities.html)
 implementation.
 [Implementing configurable externalities](https://substrate.dev/recipes/3-entrees/testing/externalities.html)
 is covered in more depth in the recipes.

--- a/docs/knowledgebase/smart-contracts/contracts-pallet.md
+++ b/docs/knowledgebase/smart-contracts/contracts-pallet.md
@@ -2,7 +2,7 @@
 title: Contracts Pallet
 ---
 
-The [Contracts pallet](https://crates.parity.io/pallet_contracts/index.html) provides
+The [Contracts pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_contracts/index.html) provides
 the ability for the runtime to deploy and execute [WebAssembly (Wasm)](https://webassembly.org/)
 smart contracts.
 
@@ -118,6 +118,6 @@ or upgradeable contracts on a Substrate based blockchain.
 ### References
 
 - Visit the reference docs for the
-  [Contracts module](https://crates.parity.io/pallet_contracts/index.html).
+  [Contracts module](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_contracts/index.html).
 - Take a look at the [repository for `wasmi`](https://github.com/paritytech/wasmi).
 - Take a look at the [repository for ink!](https://github.com/paritytech/ink).

--- a/docs/knowledgebase/smart-contracts/overview.md
+++ b/docs/knowledgebase/smart-contracts/overview.md
@@ -184,7 +184,7 @@ influence your decision on the kinds of situations you may want to use these dif
 ### References
 
 - Visit the reference docs for the
-  [Contracts pallet](https://crates.parity.io/pallet_contracts/index.html).
+  [Contracts pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_contracts/index.html).
 - Visit the reference docs for the
-  [EVM pallet](https://crates.parity.io/pallet_evm/index.html).
+  [EVM pallet](https://substrate.dev/rustdocs/v2.0.0-rc4/pallet_evm/index.html).
 - Take a look at the [repository for ink!](https://github.com/paritytech/ink).

--- a/readme.md
+++ b/readme.md
@@ -7,7 +7,9 @@ The [docs are written in markdown](docs), processed by [Docusaurus](https://docu
 
 ## Contributing
 
-Thank you for your interest in contributing to the Developer Hub and to the larger Substrate community! Please review our contributor guidelines prior to any contribution. If you have any further questions, don't hesitate to [reach out](https://matrix.to/#/!NdxrIlxGUHXYwtRGrF:matrix.parity.io?via=matrix.parity.io) on our community channels. 
+Thank you for your interest in contributing to the Developer Hub and to the larger Substrate community! Please review
+our contributor guidelines prior to any contribution. If you have any further questions, don't hesitate to
+[reach out](https://matrix.to/#/!NdxrIlxGUHXYwtRGrF:matrix.parity.io?via=matrix.parity.io) on our community channels. 
 
 ### Directory Structure
 
@@ -70,6 +72,16 @@ Heroku. Note that multilingual translations are NOT pulled in.
 2. Commit to your local repository, and then push to `staging-source` branch. This triggers the CI to build the website
 AND also pull in multilingual translations from our Crowdin project. The final built static site is then pushed to the
 `staging` branch and deployed to Heroku.
+
+### Updates
+
+There is a helper script that can be used to update `substrate.dev/rustdocs` links in the `docs/knowledgebase`
+directory.
+
+```bash
+# This examples demonstrates updating links from v2.0.0-rc3 to v2.0.0-rc4
+OLD_VERSION=v2.0.0-rc3 NEW_VERSION=v2.0.0-rc4 ./scripts/update-kb-rustdocs
+```
 
 ### Production Deployment
 

--- a/scripts/update-kb-rustdocs
+++ b/scripts/update-kb-rustdocs
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# set -xe
+set -e
+
+APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
+
+find $APP_DIR/docs/knowledgebase -type f -name "*.md" -print0 \
+ | xargs -0 sed -i -e "s/substrate.dev\/rustdocs\/$OLD_VERSION/substrate.dev\/rustdocs\/$NEW_VERSION/g"

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -112,19 +112,23 @@ class Footer extends React.Component {
             )}
           </a>
           <div>
-            <h5>Docs</h5>
-            <a href={'/docs/' + this.props.language + '/'}>
-              Getting Started
-            </a>
+            <h5>Developer Hub</h5>
             <a href={this.pageUrl("tutorials", this.props.language)}>
               Tutorials
             </a>
-            <a href="https://crates.parity.io/">Reference Docs</a>
+            <a href={'/docs/' + this.props.language + '/'}>
+              Knowledge Base
+            </a>
             <a href="https://substrate.dev/recipes/">Recipes</a>
+            <a href="https://substrate.dev/rustdocs">Reference Documents</a>
           </div>
           <div>
             <h5>Community</h5>
-            <a href={this.pageUrl("videos", this.props.language)}>Videos</a>
+            <a href="community">Community Home</a>
+            <a href="newsletter">Newsletter</a>
+            <a href="https://riot.im/app/#/room/!HzySYSaIhtyWrwiwEV:matrix.org">
+              Riot Chat
+            </a>
             <a href={this.pageUrl("seminar", this.props.language)}>Substrate Seminar</a>
             <a
               href="http://stackoverflow.com/questions/tagged/substrate"
@@ -132,9 +136,6 @@ class Footer extends React.Component {
               rel="noreferrer noopener"
             >
               Stack Overflow
-            </a>
-            <a href="https://riot.im/app/#/room/!HzySYSaIhtyWrwiwEV:matrix.org">
-              Riot Chat
             </a>
             <a
               href="https://twitter.com/ParityTech"

--- a/website/core/Footer.js
+++ b/website/core/Footer.js
@@ -124,8 +124,8 @@ class Footer extends React.Component {
           </div>
           <div>
             <h5>Community</h5>
-            <a href="community">Community Home</a>
-            <a href="newsletter">Newsletter</a>
+            <a href={this.pageUrl("community", this.props.language)}>Community Home</a>
+            <a href={this.pageUrl("newsletter", this.props.language)}>Newsletter</a>
             <a href="https://riot.im/app/#/room/!HzySYSaIhtyWrwiwEV:matrix.org">
               Riot Chat
             </a>

--- a/website/pages/en/community.js
+++ b/website/pages/en/community.js
@@ -25,9 +25,7 @@ const translate = require('../../server/translate').translate;
 function Community(props) {
   const { config: siteConfig, language = "" } = props;
   const { baseUrl, docsUrl } = siteConfig;
-  const docsPart = `${docsUrl ? `${docsUrl}/` : ""}`;
   const langPart = `${language ? `${language}/` : ""}`;
-  const docUrl = doc => `${baseUrl}${docsPart}${langPart}${doc}`;
   const pageUrl = doc => `${baseUrl}${langPart}${doc}`
 
   const CommunityResource = props => (
@@ -38,50 +36,17 @@ function Community(props) {
     </div>
   );
 
-  const StackOverflow = () => (
-    <CommunityResource title="StackOverflow">
-      Stack Overflow is a great place to ask code-level questions or if you’re
-      stuck with a specific error. Read through the existing questions/answers
-      or ask your own!
-      <p>
-        <translate>Tags:</translate>
-        <Button
-          target="_blank"
-          variant="info"
-          size="sm"
-          href="https://stackoverflow.com/questions/tagged/substrate"
-          className="m-1"
-        >
-          <code>substrate</code>
-        </Button>
-        <Button
-          target="_blank"
-          variant="dark"
-          size="sm"
-          href="https://stackoverflow.com/questions/tagged/ink"
-          className="m-1"
-        >
-          <code>ink</code>
-        </Button>
-        <Button
-          target="_blank"
-          variant="primary"
-          size="sm"
-          href="https://stackoverflow.com/questions/tagged/parity-io"
-          className="m-1"
-        >
-          <code>parity-io</code>
-        </Button>
-        <Button
-          target="_blank"
-          variant="warning"
-          size="sm"
-          href="https://stackoverflow.com/questions/tagged/rust"
-          className="m-1"
-        >
-          <code>rust</code>
-        </Button>
-      </p>
+  const Newsletter = () => (
+    <CommunityResource title="Newsletter">
+      <p>Subscribe to the Substrate newsletter to hear about updates and events.</p>
+      <Button
+        variant="secondary"
+        size="sm"
+        href="newsletter"
+        className="m-1 primary-color"
+      >
+        Subscribe
+      </Button>
     </CommunityResource>
   );
 
@@ -135,79 +100,7 @@ function Community(props) {
     </CommunityResource>
   );
 
-  const TwitchStream = () => (
-    <CommunityResource title={<translate>Twitch Stream</translate>}>
-      <p>
-        <translate>
-          You might catch us streaming cool live coding sessions. Follow our channel
-          to make sure you never miss a stream!
-        </translate>
-      </p>
-      <iframe
-        src="https://player.twitch.tv/?channel=paritylivecoding"
-        frameBorder="0"
-        allowFullScreen={true}
-        scrolling="no"
-        height="378"
-        width="620"
-      />
-      <p>
-        <Button
-          target="_blank"
-          variant="secondary"
-          size="sm"
-          href="https://www.twitch.tv/paritylivecoding"
-          style={{ backgroundColor: "#6441A5" }}
-          className="m-1"
-        >
-          Twitch Channel >
-        </Button>
-      </p>
-    </CommunityResource>
-  );
-
-  const AwesomeSubstrate = () => (
-    <CommunityResource title={<translate>Awesome Substrate</translate>}>
-      <p>
-        <translate>
-          An "awesome list" of up-to-date news, events, and onboarding materials for Substrate.
-        </translate>
-      </p>
-      <p>
-        <Button
-          target="_blank"
-          variant="secondary"
-          size="sm"
-          href="https://substrate.dev/awesome-substrate/"
-          className="m-1 primary-color"
-        >
-          Awesome Substrate
-        </Button>
-      </p>
-    </CommunityResource>
-  );
-
-  const Videos = () => (
-    <CommunityResource title={<translate>Videos</translate>}>
-      <p>
-        <translate>
-          A list of great videos to help you learn about Substrate.
-        </translate>
-      </p>
-      <p>
-        <Button
-          variant="secondary"
-          size="sm"
-          href={pageUrl("videos")}
-          className="m-1 primary-color"
-        >
-          Videos
-        </Button>
-      </p>
-    </CommunityResource>
-  );
-
-  const SubstrateSeminar = () => (
+  const Seminar = () => (
     <CommunityResource title={<translate>Substrate Seminar</translate>}>
       <p>
         <translate>
@@ -257,6 +150,91 @@ function Community(props) {
     </CommunityResource>
   );
 
+  const StackOverflow = () => (
+    <CommunityResource title="StackOverflow">
+      Stack Overflow is a great place to ask code-level questions or if you’re
+      stuck with a specific error. Read through the existing questions/answers
+      or ask your own!
+      <p>
+        <translate>Tags:</translate>
+        <Button
+          target="_blank"
+          variant="dark"
+          size="sm"
+          href="https://stackoverflow.com/questions/tagged/substrate"
+          className="m-1"
+        >
+          <code>substrate</code>
+        </Button>
+        <Button
+          target="_blank"
+          variant="dark"
+          size="sm"
+          href="https://stackoverflow.com/questions/tagged/ink"
+          className="m-1"
+        >
+          <code>ink</code>
+        </Button>
+        <Button
+          target="_blank"
+          variant="dark"
+          size="sm"
+          href="https://stackoverflow.com/questions/tagged/parity-io"
+          className="m-1"
+        >
+          <code>parity-io</code>
+        </Button>
+        <Button
+          target="_blank"
+          variant="dark"
+          size="sm"
+          href="https://stackoverflow.com/questions/tagged/rust"
+          className="m-1"
+        >
+          <code>rust</code>
+        </Button>
+      </p>
+    </CommunityResource>
+  );
+
+  const Twitter = () => (
+    <CommunityResource title="Twitter">
+      <p>Follow us on Twitter to stay up-to-date.</p>
+      <Button
+        variant="secondary"
+        size="sm"
+        href="https://twitter.com/substrate_io"
+        className="m-1 primary-color"
+      >
+        Substrate
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        href="https://twitter.com/paritytech"
+        className="m-1 primary-color"
+      >
+        Parity Technologies
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        href="https://twitter.com/Polkadot"
+        className="m-1 primary-color"
+      >
+        Polkadot Network
+      </Button>
+      <Button
+        variant="secondary"
+        size="sm"
+        href="https://twitter.com/kusamanetwork"
+        className="m-1 primary-color"
+      >
+        Kusama Network
+      </Button>
+    </CommunityResource>
+  );
+
   const Events = () => (
     <CommunityResource title={<translate>Events & Meetups</translate>}>
       <p>
@@ -268,12 +246,33 @@ function Community(props) {
       <p>
         <Button
           target="_blank"
-          variant="secondary"
+          variant="dark"
           size="sm"
           href="https://www.meetup.com/parity/"
-          className="m-1 primary-color"
+          className="m-1"
         >
           Events
+        </Button>
+      </p>
+    </CommunityResource>
+  );
+
+  const AwesomeSubstrate = () => (
+    <CommunityResource title={<translate>Awesome Substrate</translate>}>
+      <p>
+        <translate>
+          An "awesome list" of up-to-date news, events, and onboarding materials for Substrate.
+        </translate>
+      </p>
+      <p>
+        <Button
+          target="_blank"
+          variant="secondary"
+          size="sm"
+          href="https://substrate.dev/awesome-substrate/"
+          className="m-1 primary-color"
+        >
+          Awesome Substrate
         </Button>
       </p>
     </CommunityResource>
@@ -296,13 +295,13 @@ function Community(props) {
               be happy for you to join!
             </translate>
           </p>
-          <StackOverflow />
+          <Newsletter />
           <RiotChat />
-          <Videos />
-          <SubstrateSeminar />
+          <Seminar />
+          <StackOverflow />
+          <Twitter />
           <Events />
           <AwesomeSubstrate />
-          <TwitchStream />
         </Container>
       </div>
     </div>

--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -51,11 +51,10 @@ const siteConfig = {
 
 	// For no header links in the top nav bar -> headerLinks: [],
 	headerLinks: [
-		{ doc: 'index', label: 'Docs' },
-		{ href: 'https://substrate.dev/recipes/', label: 'Recipes' },
 		{ page: 'tutorials', label: 'Tutorials' },
-		{ page: 'community', label: 'Community' },
-		{ href: 'https://github.com/paritytech/substrate', label: 'GitHub' },
+		{ doc: 'index', label: 'Knowledge Base' },
+		{ href: 'https://substrate.dev/recipes/', label: 'Recipes' },
+		{ href: 'https://substrate.dev/rustdocs/', label: 'Reference Documents' },
 		{ search: true }
 	],
 


### PR DESCRIPTION
I would suggest that the best way to review this is to take a quick look at the diff & then pull it down and run it locally.

- Rustdocs should point to substrate.dev/rustdocs
- Minor structural changes to reinforce latest DevHub POV