### PR TITLE
Enable running check-links locally with web3f/link-checker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Q: What is this dockerfile for?
 # A: https://docusaurus.io/docs/en/docker
 
-FROM node:8.11.4
+FROM node:12.13.0
 
 WORKDIR /app/website
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # Q: What is this dockerfile for?
 # A: https://docusaurus.io/docs/en/docker
 
-FROM node:12.13.0
+# Unify with our CI test image node version
+FROM node:10.15.2
 
 WORKDIR /app/website
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,13 @@
 version: "3"
 
 services:
-  docusaurus:
+  link-checker:
+    image: web3f/link-checker:v1.0.1
+    command: /bin/bash -c "sleep 15 && linkchecker --ignore-url=\"^(?:(?!\/en\/).)*$$\" --check-extern http://main:3000/"
+    depends_on:
+      - main
+
+  main:
     build: .
     ports:
       - 3000:3000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,7 @@ version: "3"
 services:
   link-checker:
     image: web3f/link-checker:v1.0.1
-    command: /bin/bash -c "sleep 15 && linkchecker --ignore-url=\"^(?:(?!\/en\/).)*$$\" --check-extern http://main:3000/"
+    command: /bin/bash -c "sleep 20 && linkchecker --ignore-url=\"^(?:(?!\/en\/).)*$$\" --check-extern http://main:3000/"
     depends_on:
       - main
 

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,7 @@
     "rename-version": "docusaurus-rename-version",
     "crowdin-upload": "crowdin --config ../crowdin.yaml upload sources --auto-update -b master",
     "crowdin-download": "crowdin --config ../crowdin.yaml download -b master",
-    "check-links": "docker-compose up",
+    "check-links": "yarn check-links-cleanup && docker-compose up",
     "check-links-cleanup": "docker-compose down --remove-orphans"
   },
   "devDependencies": {

--- a/website/package.json
+++ b/website/package.json
@@ -9,7 +9,8 @@
     "rename-version": "docusaurus-rename-version",
     "crowdin-upload": "crowdin --config ../crowdin.yaml upload sources --auto-update -b master",
     "crowdin-download": "crowdin --config ../crowdin.yaml download -b master",
-    "check-links": "yarn blc http://localhost:3000 -ro --exclude \"http://localhost:3000/docs/ru\" --exclude \"http://localhost:3000/docs/zh-CN\" --exclude \"https://playground.substrate.dev/\" --exclude \"https://player.twitch.tv/?channel=paritylivecoding\" --exclude \"http://localhost:8000/\""
+    "check-links": "docker-compose up",
+    "check-links-cleanup": "docker-compose down --remove-orphans"
   },
   "devDependencies": {
     "broken-link-checker": "^0.7.8",


### PR DESCRIPTION
@danforbes  @joepetrowski 

With this PR, you can run in the `website` directory: 
- `yarn check-links`: this will build our doc docusaurus website into an image, download the `web3f/link-checker` image (if not existed), and start them in containers to check links. Note that by the end of running link-checker, the docusaurus website will not kill itself, so dev need to terminate it manually with `ctrl-C`.
- `yarn check-links-cleanup`: there will be some docker container traces left in your machine after running the above cmd. Use this cmd to clean them up.

You need to have `docker` and `docker-compose` installed to run these two commands.

Fixes: #592. This unifies link checking locally and in the CI. 

Running result on my machine:

![Screenshot 2020-07-06 at 16 18 38](https://user-images.githubusercontent.com/898091/86572156-233e0e80-bfa5-11ea-889e-141529940812.png)
