### PR TITLE
Fixed typo and inconsistent guidance

### DIFF
--- a/docs/tutorials/start-a-private-network/customchain.md
+++ b/docs/tutorials/start-a-private-network/customchain.md
@@ -18,7 +18,7 @@ The first participant can launch her node with:
 ```bash
 ./target/release/node-template \
   --base-path /tmp/node01 \
-  --chain=./customSpecRaw.json \
+  --chain ./customSpecRaw.json \
   --port 30333 \
   --ws-port 9944 \
   --rpc-port 9933 \
@@ -149,7 +149,7 @@ Make sure you delete the file that contains the keys when you are done.
 ## Subsequent Participants Join
 
 Subsequent validators can now join the network. This can be done by specifying the `--bootnodes`
-paramter as Bob did previously.
+parameter as Bob did previously.
 
 ```bash
 ./target/release/node-template \


### PR DESCRIPTION
The "paramter" typo was corrected, and usage of the `--chain` flag was written different (line 21 and 157). Minor stuff, but it added unnecessary noise to the documentation.


- [X] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [X] Is the writing:
  - [X] Clear: No jargon.
  - [X] Precise: No ambiguous meanings.
  - [X] Concise: Free of superfluous detail.
- [X] Does it follow our style guide?
- [X] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [X] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [X] Do links go to rustdocs or devhub articles rather than code?
- [X] If this PR addresses an issue in the queue, have you referenced it in the description?
