### PR TITLE
use release version v2.0.0 to avoid yarn start issue

### DIFF
--- a/docs/tutorials/create-your-first-substrate-chain/setup.md
+++ b/docs/tutorials/create-your-first-substrate-chain/setup.md
@@ -98,7 +98,7 @@ Now you can proceed to set up the front-end template with these commands.
 
 ```bash
 # Clone the code from github
-git clone -b v2.0.0-rc6 --depth 1 https://github.com/substrate-developer-hub/substrate-front-end-template
+git clone -b v2.0.0 --depth 1 https://github.com/substrate-developer-hub/substrate-front-end-template
 
 # Install the dependencies
 cd substrate-front-end-template


### PR DESCRIPTION
We cannot run `yarn start` on v2.0.0-rc6 

ref: https://github.com/substrate-developer-hub/substrate-front-end-template/issues/128#issuecomment-695773889

This issue was already fixed on v2.0.0 so we'd better to update the document guide also!