### PR TITLE
removed redundant word

### DIFF
--- a/docs/tutorials/add-a-pallet/configure-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/configure-a-pallet.md
@@ -159,7 +159,7 @@ impl pallet_nicks::Trait for Runtime {
 ### Adding Nicks to the `construct_runtime!` Macro
 
 Next, we need to add the Nicks pallet to the `construct_runtime!` macro. For this, we need to
-determine the types that the pallet exposes so that we can tell the our runtime that they exist. The
+determine the types that the pallet exposes so that we can tell our runtime that they exist. The
 complete list of possible types can be found in the
 [`construct_runtime!` macro documentation](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.construct_runtime.html).
 


### PR DESCRIPTION
deleted 'the' from 'the our'... could have gone the other way (delete 'our' leaving 'the)


- [ ] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [ ] Is the writing:
  - [ ] Clear: No jargon.
  - [ ] Precise: No ambiguous meanings.
  - [ ] Concise: Free of superfluous detail.
- [ ] Does it follow our style guide?
- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [ ] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [ ] Do links go to rustdocs or devhub articles rather than code?
- [ ] If this PR addresses an issue in the queue, have you referenced it in the description?
