### PR TITLE
Update Rustdocs links

### DIFF
--- a/docs/knowledgebase/advanced/block-import.md
+++ b/docs/knowledgebase/advanced/block-import.md
@@ -15,22 +15,22 @@ are later checked for validity and discarded if they are not valid. Elements tha
 imported into the node's local state.
 
 The import queue is codified abstractly in Substrate by means of the
-[`ImportQueue` trait](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_consensus/import_queue/trait.ImportQueue.html).
+[`ImportQueue` trait](https://substrate.dev/rustdocs/v2.0.0/sp_consensus/import_queue/trait.ImportQueue.html).
 The use of a trait allows each consensus engine to provide its own specialized implementation of the
 import queue, which may take advantage of optimization opportunities such as verifying multiple
 blocks in parallel as they come in across the network.
 
 The import queue also provides some hooks via the
-[`Link` trait](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_consensus/import_queue/trait.Link.html) that can be used
+[`Link` trait](https://substrate.dev/rustdocs/v2.0.0/sp_consensus/import_queue/trait.Link.html) that can be used
 to follow its progress.
 
 ## The Basic Queue
 
 Substrate provides a default in-memory implementation of the `ImportQueue` known as the
-[`BasicQueue`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_consensus/import_queue/struct.BasicQueue.html). The
+[`BasicQueue`](https://substrate.dev/rustdocs/v2.0.0/sp_consensus/import_queue/struct.BasicQueue.html). The
 `BasicQueue` does not do any kind of optimization, rather it performs the verification and import
 steps sequentially. It does, however, abstract the notion of verification through the use of the
-[`Verifier`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_consensus/import_queue/trait.Verifier.html) trait.
+[`Verifier`](https://substrate.dev/rustdocs/v2.0.0/sp_consensus/import_queue/trait.Verifier.html) trait.
 
 Any consensus engine that relies on the `BasicQueue` must implement the `Verifier` trait. The
 `Verifier` is typically responsible for tasks such as checking
@@ -41,12 +41,12 @@ the block is signed by the appropriate authority.
 
 When the import queue is ready to import a block, it passes the block in question to a method
 provided by the
-[`BlockImport` trait](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_consensus/block_import/trait.BlockImport.html).
+[`BlockImport` trait](https://substrate.dev/rustdocs/v2.0.0/sp_consensus/block_import/trait.BlockImport.html).
 This `BlockImport` trait provides the behavior of importing a block into the node's local state
 database.
 
 One implementor of the `BlockImport` trait that is used in every Substrate node is the
-[`Client`](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_service/client/index.html), which contains the node's entire
+[`Client`](https://substrate.dev/rustdocs/v2.0.0/sc_service/client/index.html), which contains the node's entire
 block database. When a block is imported into the client, it is added to the main database of blocks
 that the node knows about.
 
@@ -59,13 +59,13 @@ another struct that also implements `BlockImport`. This nesting leads to the ter
 pipeline".
 
 An example of this wrapping is the
-[`PowBlockImport`](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_consensus_pow/struct.PowBlockImport.html), which
+[`PowBlockImport`](https://substrate.dev/rustdocs/v2.0.0/sc_consensus_pow/struct.PowBlockImport.html), which
 holds a reference to another type that also implements `BlockImport`. This allows the PoW consensus
 engine to do its own import-related bookkeeping and then pass the block to the nested `BlockImport`,
 probably the client. This pattern is also demonstrated in
-[`AuraBlockImport`](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_consensus_aura/struct.AuraBlockImport.html),
-[`BabeBlockImport`](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_consensus_babe/struct.BabeBlockImport.html), and
-[`GrandpaBlockImport`](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_finality_grandpa/struct.GrandpaBlockImport.html).
+[`AuraBlockImport`](https://substrate.dev/rustdocs/v2.0.0/sc_consensus_aura/struct.AuraBlockImport.html),
+[`BabeBlockImport`](https://substrate.dev/rustdocs/v2.0.0/sc_consensus_babe/struct.BabeBlockImport.html), and
+[`GrandpaBlockImport`](https://substrate.dev/rustdocs/v2.0.0/sc_finality_grandpa/struct.GrandpaBlockImport.html).
 
 `BlockImport` nesting need not be limited to one level. In fact, it is common for nodes that use
 both an authoring engine and a finality gadget to layer the nesting even more deeply. For example,

--- a/docs/knowledgebase/advanced/codec.md
+++ b/docs/knowledgebase/advanced/codec.md
@@ -201,7 +201,7 @@ that is written in Rust and maintained by Parity Technologies.
 ## References
 
 - Visit the reference docs for the
-  [`parity-scale-codec`](https://substrate.dev/rustdocs/v2.0.0-rc6/parity_scale_codec/index.html).
+  [`parity-scale-codec`](https://substrate.dev/rustdocs/v2.0.0/parity_scale_codec/index.html).
 
 - Visit the auxiliary encoding section of the
   [Polkadot runtime environment specification](https://github.com/w3f/polkadot-spec/).

--- a/docs/knowledgebase/advanced/consensus.md
+++ b/docs/knowledgebase/advanced/consensus.md
@@ -50,7 +50,7 @@ parent. Forks must be resolved such that only one, canonical chain exists.
 
 A fork choice rule is an algorithm that takes a blockchain and selects the "best" chain, and thus
 the one that should be extended. Substrate exposes this concept through the
-[`SelectChain` Trait](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_consensus/trait.SelectChain.html).
+[`SelectChain` Trait](https://substrate.dev/rustdocs/v2.0.0/sp_consensus/trait.SelectChain.html).
 
 Substrate allows you to write a custom fork choice rule, or use one that comes out of the box. For
 example:
@@ -59,7 +59,7 @@ example:
 
 The longest chain rule simply says that the best chain is the longest chain. Substrate provides this
 chain selection rule with the
-[`LongestChain` struct](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_consensus/struct.LongestChain.html).
+[`LongestChain` struct](https://substrate.dev/rustdocs/v2.0.0/sc_consensus/struct.LongestChain.html).
 GRANDPA uses the longest chain rule for voting.
 
 ![longest chain rule](assets/consensus-longest-chain.png)
@@ -129,12 +129,12 @@ Developers are always welcome to provide their own custom consensus algorithms.
 
 ### Aura
 
-[Aura](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_consensus_aura/index.html) provides a slot-based
+[Aura](https://substrate.dev/rustdocs/v2.0.0/sc_consensus_aura/index.html) provides a slot-based
 block authoring mechanism. In Aura a known set of authorities take turns producing blocks.
 
 ### BABE
 
-[BABE](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_consensus_babe/index.html) also provides slot-based
+[BABE](https://substrate.dev/rustdocs/v2.0.0/sc_consensus_babe/index.html) also provides slot-based
 block authoring with a known set of validators. In these ways it is similar to Aura. Unlike Aura,
 slot assignment is based on the evaluation of a Verifiable Random Function (VRF). Each validator is
 assigned a weight for an _epoch._ This epoch is broken up into slots and the validator evaluates its
@@ -149,7 +149,7 @@ in a given slot. These "secondary" slot assignments allow BABE to achieve a cons
 
 ### Proof of Work
 
-[Proof-of-work](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_consensus_pow/index.html) block authoring
+[Proof-of-work](https://substrate.dev/rustdocs/v2.0.0/sc_consensus_pow/index.html) block authoring
 is not slot-based and does not require a known authority set. In proof of work, anyone can produce a
 block at any time, so long as they can solve a computationally challenging problem (typically a hash
 preimage search). The difficulty of this problem can be tuned to provide a statistical target block
@@ -157,7 +157,7 @@ time.
 
 ### GRANDPA
 
-[GRANDPA](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_finality_grandpa/index.html) provides block
+[GRANDPA](https://substrate.dev/rustdocs/v2.0.0/sc_finality_grandpa/index.html) provides block
 finalization. It has a known weighted authority set like BABE. However, GRANDPA does not author
 blocks; it just listens to gossip about blocks that have been produced by some authoring engine like
 the three discussed above. GRANDPA validators vote on _chains,_ not _blocks,_ i.e. they vote on a
@@ -173,7 +173,7 @@ coordination with the runtime. Examples include adjustable difficulty in proof o
 rotation in proof of authority, and stake-based weighting in proof-of-stake networks.
 
 To accommodate these consensus features, Substrate has the concept of a
-[`DigestItem`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_runtime/enum.DigestItem.html), a message
+[`DigestItem`](https://substrate.dev/rustdocs/v2.0.0/sp_runtime/enum.DigestItem.html), a message
 passed from the outer part of the node, where consensus lives, to the runtime, or vice versa.
 
 ## Learn More

--- a/docs/knowledgebase/advanced/cryptography.md
+++ b/docs/knowledgebase/advanced/cryptography.md
@@ -9,7 +9,7 @@ This document offers a conceptual overview of the cryptography used in Substrate
 Hash functions are used in Substrate to map arbitrary sized data to fixed-sized values.
 
 Substrate provides two hash algorithms out of the box, but can support any hash algorithm which
-implements the [`Hasher` trait](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_core/trait.Hasher.html).
+implements the [`Hasher` trait](https://substrate.dev/rustdocs/v2.0.0/sp_core/trait.Hasher.html).
 
 ### xxHash
 
@@ -39,7 +39,7 @@ Public-key cryptography is used in Substrate to provide a robust authentication 
 
 Substrate provides multiple different cryptographic schemes and is generic such that it can support
 anything which implements the
-[`Pair` trait](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_core/crypto/trait.Pair.html).
+[`Pair` trait](https://substrate.dev/rustdocs/v2.0.0/sp_core/crypto/trait.Pair.html).
 
 ### ECDSA
 
@@ -87,7 +87,7 @@ but only ECDSA signatures communicate their public key.
 ### References
 
 - Take a look at the
-  [`Hash`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_runtime/traits/trait.Hash.html) trait needed for
+  [`Hash`](https://substrate.dev/rustdocs/v2.0.0/sp_runtime/traits/trait.Hash.html) trait needed for
   implementing new hashing algorithms.
-- Take a look at the [`Pair`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_core/crypto/trait.Pair.html)
+- Take a look at the [`Pair`](https://substrate.dev/rustdocs/v2.0.0/sp_core/crypto/trait.Pair.html)
   trait needed for implementing new cryptographic schemes.

--- a/docs/knowledgebase/advanced/executor.md
+++ b/docs/knowledgebase/advanced/executor.md
@@ -69,7 +69,7 @@ needs to know the `spec_name`, `spec_version` and `authoring_version` of both th
 runtime.
 
 The runtime provides the following
-[versioning properties](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_version/struct.RuntimeVersion.html):
+[versioning properties](https://substrate.dev/rustdocs/v2.0.0/sp_version/struct.RuntimeVersion.html):
 
 - `spec_name`: The identifier for the different Substrate runtimes.
 
@@ -128,10 +128,10 @@ TODO
 ### References
 
 - Check out the different
-  [Execution Strategies](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_client_api/execution_extensions/struct.ExecutionStrategies.html).
+  [Execution Strategies](https://substrate.dev/rustdocs/v2.0.0/sc_client_api/execution_extensions/struct.ExecutionStrategies.html).
 
 - Take a look at the different
-  [Execution Strategy Options](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_state_machine/enum.ExecutionStrategy.html)
+  [Execution Strategy Options](https://substrate.dev/rustdocs/v2.0.0/sp_state_machine/enum.ExecutionStrategy.html)
 
 - Review the
-  [Runtime Version definition](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_version/struct.RuntimeVersion.html).
+  [Runtime Version definition](https://substrate.dev/rustdocs/v2.0.0/sp_version/struct.RuntimeVersion.html).

--- a/docs/knowledgebase/advanced/storage.md
+++ b/docs/knowledgebase/advanced/storage.md
@@ -46,7 +46,7 @@ each block header. This is used to easily verify the state of the blockchain and
 light clients to verify proofs.
 
 This trie only stores content for the canonical chain, not forks. There is a separate
-[`state_db` layer](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_state_db/index.html) that maintains the
+[`state_db` layer](https://substrate.dev/rustdocs/v2.0.0/sc_state_db/index.html) that maintains the
 trie state with references counted in memory for all that is non-canonical.
 
 ### Child Trie
@@ -77,9 +77,9 @@ reading to learn how to calculate storage keys for the different types of storag
 To calculate the key for a simple [Storage Value](../runtime/storage#Storage-Value), take the
 [TwoX 128 hash](https://github.com/Cyan4973/xxHash) of the name of the module that contains the
 Storage Value and append to it the TwoX 128 hash of the name of the Storage Value itself. For
-example, the [Sudo](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_sudo/index.html) pallet exposes a
+example, the [Sudo](https://substrate.dev/rustdocs/v2.0.0/pallet_sudo/index.html) pallet exposes a
 Storage Value item named
-[`Key`](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_sudo/struct.Module.html#method.key):
+[`Key`](https://substrate.dev/rustdocs/v2.0.0/pallet_sudo/struct.Module.html#method.key):
 
 ```
 twox_128("Sudo")                   = "0x5c0d1176a568c1f92944340dbfed9e9c"
@@ -186,7 +186,7 @@ example, after you remove the first 32 hexadecimal characters that represent the
 
 ## Runtime Storage API
 
-Substrate's [FRAME Support crate](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_support/index.html)
+Substrate's [FRAME Support crate](https://substrate.dev/rustdocs/v2.0.0/frame_support/index.html)
 provides utilities for generating unique, deterministic keys for your runtime's storage items. These
 storage items are placed in the [state trie](#Trie-Abstraction) and are accessible by
 [querying the trie by key](#Querying-Storage).
@@ -200,4 +200,4 @@ storage items are placed in the [state trie](#Trie-Abstraction) and are accessib
 ### References
 
 - Visit the reference docs for
-  [`paritytech/trie`](https://substrate.dev/rustdocs/v2.0.0-rc6/trie_db/trait.Trie.html).
+  [`paritytech/trie`](https://substrate.dev/rustdocs/v2.0.0/trie_db/trait.Trie.html).

--- a/docs/knowledgebase/integrate/chain-spec.md
+++ b/docs/knowledgebase/integrate/chain-spec.md
@@ -8,7 +8,7 @@ and what consensus-critical state it must have at genesis.
 
 ## Structure of a Chain Spec
 
-The [`ChainSpec` struct](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_service/struct.GenericChainSpec.html)
+The [`ChainSpec` struct](https://substrate.dev/rustdocs/v2.0.0/sc_service/struct.GenericChainSpec.html)
 separates the information contained in a chain spec into two parts. A node can use a `ChainSpec`
 instance to create a genesis block.
 
@@ -147,9 +147,9 @@ After the conversion process, the above snippet looks like this:
 ### Learn More
 
 - Rustdocs for the
-  [`ChainSpec` struct](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_service/struct.GenericChainSpec.html)
+  [`ChainSpec` struct](https://substrate.dev/rustdocs/v2.0.0/sc_service/struct.GenericChainSpec.html)
 - Rustdocs for the
-  [`ProtocolId` struct](https://substrate.dev/rustdocs/v2.0.0-rc6/sc_network/config/struct.ProtocolId.html)
+  [`ProtocolId` struct](https://substrate.dev/rustdocs/v2.0.0/sc_network/config/struct.ProtocolId.html)
 
 ### Examples
 

--- a/docs/knowledgebase/runtime/debugging.md
+++ b/docs/knowledgebase/runtime/debugging.md
@@ -10,7 +10,7 @@ are some restrictions when operating inside of a `no_std` environment like the S
 
 To facilitate the debugging of the runtime, Substrate provides extra tools for `Print` debugging (or
 tracing). You can use the
-[`print` function](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_runtime/fn.print.html) to log the status
+[`print` function](https://substrate.dev/rustdocs/v2.0.0/sp_runtime/fn.print.html) to log the status
 of the runtime execution.
 
 ```rust
@@ -50,7 +50,7 @@ The values are printed in the terminal or the standard output if the Error gets 
 
 The Printable trait is meant to be a way to print from the runtime in `no_std` and in `std`. The
 `print` function works with any type that implements the
-[`Printable` trait](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_runtime/traits/trait.Printable.html).
+[`Printable` trait](https://substrate.dev/rustdocs/v2.0.0/sp_runtime/traits/trait.Printable.html).
 Substrate implements this trait for some types (`u8`, `u32`, `u64`, `usize`, `&[u8]`, `&str`) by
 default. You can also implement it for your own custom types. Here is an example of implementing it
 for a pallet's `Error` type using the node-template as the example codebase.
@@ -134,7 +134,7 @@ gets called.
 The `print` function works well when you just want to print and you have an implementation of the
 `Printable` trait. In some cases you may want to do more than print, or not bother with
 Substrate-specific traits just for debugging purposes. The
-[`if_std!` macro](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_std/macro.if_std.html) is for exactly
+[`if_std!` macro](https://substrate.dev/rustdocs/v2.0.0/sp_std/macro.if_std.html) is for exactly
 this situation.
 
 One caveat of using this macro is that the code inside will only execute when you are actually

--- a/docs/knowledgebase/runtime/events.md
+++ b/docs/knowledgebase/runtime/events.md
@@ -83,7 +83,7 @@ decl_module! {
 ```
 
 The default behavior of this function is to call
-[`deposit_event`](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_system/struct.Module.html#method.deposit_event)
+[`deposit_event`](https://substrate.dev/rustdocs/v2.0.0/frame_system/struct.Module.html#method.deposit_event)
 from the FRAME system, which writes the event to storage.
 
 This function places the event in the System module's runtime storage for that block. At the
@@ -126,6 +126,6 @@ runtime events are used:
 
 ### References
 
-- [`decl_event!` macro](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_support/macro.decl_event.html)
-- [`decl_module!` macro](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_support/macro.decl_module.html)
-- [`construct_runtime!` macro](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_support/macro.construct_runtime.html)
+- [`decl_event!` macro](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.decl_event.html)
+- [`decl_module!` macro](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.decl_module.html)
+- [`construct_runtime!` macro](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.construct_runtime.html)

--- a/docs/knowledgebase/runtime/execution.md
+++ b/docs/knowledgebase/runtime/execution.md
@@ -67,7 +67,7 @@ calculated.
 
 ### References
 
-- [FRAME executive](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_executive/index.html)
-- [`decl_event!` macro](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_support/macro.decl_event.html)
-- [`decl_storage!` macro](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_support/macro.decl_storage.html)
-- [`construct_runtime!` macro](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_support/macro.construct_runtime.html)
+- [FRAME executive](https://substrate.dev/rustdocs/v2.0.0/frame_executive/index.html)
+- [`decl_event!` macro](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.decl_event.html)
+- [`decl_storage!` macro](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.decl_storage.html)
+- [`construct_runtime!` macro](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.construct_runtime.html)

--- a/docs/knowledgebase/runtime/fees.md
+++ b/docs/knowledgebase/runtime/fees.md
@@ -24,15 +24,15 @@ A transaction fee consists of two parts:
 
 - `length_fee`: A per-byte fee that is multiplied by the length, in bytes, of the encoded extrinsic.
   See
-  [`TransactionByteFee`](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_transaction_payment/trait.Trait.html#associatedtype.TransactionByteFee).
+  [`TransactionByteFee`](https://substrate.dev/rustdocs/v2.0.0/pallet_transaction_payment/trait.Trait.html#associatedtype.TransactionByteFee).
 - `weight_fee`: A fee based on the weight of the extrinsic, which is a function of two parameters.
   One, an `ExtrinsicBaseWeight` that is declared in the runtime and applies to all extrinsics. The
   base weight covers inclusion overhead like signature verification. Two, a flexible `#[weight]`
   annotation that accounts for an extrinsic's complexity. In order to convert the weight to
   `Currency`, the runtime must define a
-  [`WeightToFee`](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_transaction_payment/trait.Trait.html#associatedtype.WeightToFee)
+  [`WeightToFee`](https://substrate.dev/rustdocs/v2.0.0/pallet_transaction_payment/trait.Trait.html#associatedtype.WeightToFee)
   struct that implements a conversion function,
-  [`Convert<Weight,Balance>`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_runtime/traits/trait.Convert.html).
+  [`Convert<Weight,Balance>`](https://substrate.dev/rustdocs/v2.0.0/sp_runtime/traits/trait.Convert.html).
 
 Based on the above, the final fee of a dispatchable is:
 
@@ -53,13 +53,13 @@ block construction logic perform checks prior to adding an extrinsic to a block.
 
 The above formula gives a fee that is always the same for the same input. However, weight can be
 dynamic and, based on how
-[`WeightToFee`](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_transaction_payment/trait.Trait.html#associatedtype.WeightToFee)
+[`WeightToFee`](https://substrate.dev/rustdocs/v2.0.0/pallet_transaction_payment/trait.Trait.html#associatedtype.WeightToFee)
 is defined, the final fee can include some degree of variability. To fulfill this requirement,
 Substrate provides:
 
-- [`NextFeeMultiplier`](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_transaction_payment/struct.Module.html#method.next_fee_multiplier):
+- [`NextFeeMultiplier`](https://substrate.dev/rustdocs/v2.0.0/pallet_transaction_payment/struct.Module.html#method.next_fee_multiplier):
   A configurable multiplier stored in the Transaction Payment module.
-- [`FeeMultiplierUpdate`](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_transaction_payment/trait.Trait.html#associatedtype.FeeMultiplierUpdate):
+- [`FeeMultiplierUpdate`](https://substrate.dev/rustdocs/v2.0.0/pallet_transaction_payment/trait.Trait.html#associatedtype.FeeMultiplierUpdate):
   A configurable parameter for a runtime to describe how this multiplier can change.
 
 `NextFeeMultiplier` has the type `Fixed64`, which can represent a fixed point number. So, given the
@@ -175,7 +175,7 @@ fn my_dispatchable() {
 
 Dispatches in this class represent normal user-triggered transactions. These types of dispatches may
 only consume a portion of a block's total weight limit; this portion can be found by examining the
-[`AvailableBlockRatio`](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
+[`AvailableBlockRatio`](https://substrate.dev/rustdocs/v2.0.0/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
 Normal dispatches are sent to the [transaction pool](../learn-substrate/tx-pool).
 
 #### Operational Dispatches
@@ -183,7 +183,7 @@ Normal dispatches are sent to the [transaction pool](../learn-substrate/tx-pool)
 As opposed to normal dispatches, which represent _usage_ of network capabilities, operational
 dispatches are those that _provide_ network capabilities. These types of dispatches may consume the
 entire weight limit of a block, which is to say that they are not bound by the
-[`AvailableBlockRatio`](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
+[`AvailableBlockRatio`](https://substrate.dev/rustdocs/v2.0.0/frame_system/trait.Trait.html#associatedtype.AvailableBlockRatio).
 Dispatches in this class are given maximum priority and are exempt from paying the `length_fee`.
 
 #### Mandatory Dispatches
@@ -385,7 +385,7 @@ payment module drawing inspiration from Transaction Payment.
 
 - Dedicated [weight documentation](../learn-substrate/weight)
 - [Example module](https://github.com/paritytech/substrate/blob/master/frame/example/src/lib.rs)
-- [SignedExtension](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_runtime/traits/trait.SignedExtension.html)
+- [SignedExtension](https://substrate.dev/rustdocs/v2.0.0/sp_runtime/traits/trait.SignedExtension.html)
 
 ### Examples
 

--- a/docs/knowledgebase/runtime/frame.md
+++ b/docs/knowledgebase/runtime/frame.md
@@ -76,7 +76,7 @@ individual pallets.
 
 Macro for benchmarking a FRAME runtime.
 
-- [Docs](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_benchmarking/index.html)
+- [Docs](https://substrate.dev/rustdocs/v2.0.0/frame_benchmarking/index.html)
 - [Source](https://github.com/paritytech/substrate/blob/master/frame/benchmarking/src/lib.rs)
 
 ## Prebuilt Pallets

--- a/docs/knowledgebase/runtime/index.md
+++ b/docs/knowledgebase/runtime/index.md
@@ -20,7 +20,7 @@ by implementing the traits in _primitives._
 ![Runtime Composition](assets/frame-runtime.png)
 
 For example, if you want to add smart contract functionality to your blockchain, you simply need to
-include the [Contracts](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_contracts/index.html) pallet.
+include the [Contracts](https://substrate.dev/rustdocs/v2.0.0/pallet_contracts/index.html) pallet.
 Adding this pallet will expose the smart contract interface so that users can deploy smart contracts
 that execute in Wasm.
 

--- a/docs/knowledgebase/runtime/macros.md
+++ b/docs/knowledgebase/runtime/macros.md
@@ -237,7 +237,7 @@ to convert the type to its specified value.
 
 **Docs**
 
-- [API Documentation](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_support/macro.parameter_types.html)
+- [API Documentation](https://substrate.dev/rustdocs/v2.0.0/frame_support/macro.parameter_types.html)
 
 ### impl_runtime_apis!
 
@@ -254,7 +254,7 @@ implementation in the `RuntimeApiImpl`.
 
 **Docs Notes**
 
-- [API Documentation](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_api/macro.impl_runtime_apis.html)
+- [API Documentation](https://substrate.dev/rustdocs/v2.0.0/sp_api/macro.impl_runtime_apis.html)
 - `RuntimeApi` and `RuntimeApiImpl` structs are declared. The macro also implements various helper
   traits for `RuntimeApiImpl`.
 - What developers define within `impl_runtime_apis!` macro are appended to the end of

--- a/docs/knowledgebase/runtime/origin.md
+++ b/docs/knowledgebase/runtime/origin.md
@@ -47,7 +47,7 @@ proposal.dispatch(system::RawOrigin::None.into())
 ```
 
 You can look at the source code of the
-[Sudo module](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_sudo/index.html) for a practical
+[Sudo module](https://substrate.dev/rustdocs/v2.0.0/pallet_sudo/index.html) for a practical
 implementation of this.
 
 ## Next Steps
@@ -71,4 +71,4 @@ implementation of this.
 ### References
 
 - Visit the reference docs for the
-  [`RawOrigin` enum](https://substrate.dev/rustdocs/v2.0.0-rc6/frame_system/enum.RawOrigin.html).
+  [`RawOrigin` enum](https://substrate.dev/rustdocs/v2.0.0/frame_system/enum.RawOrigin.html).

--- a/docs/knowledgebase/runtime/tests.md
+++ b/docs/knowledgebase/runtime/tests.md
@@ -41,17 +41,17 @@ requires tracking a `(AccountId: u64, Balance: u64)` mapping.
 
 ### Mock Runtime Storage
 
-The [`runtime-io`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_io/index.html) crate exposes a
-[`TestExternalities`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_io/type.TestExternalities.html)
+The [`runtime-io`](https://substrate.dev/rustdocs/v2.0.0/sp_io/index.html) crate exposes a
+[`TestExternalities`](https://substrate.dev/rustdocs/v2.0.0/sp_io/type.TestExternalities.html)
 implementation frequently used for mocking storage in tests. It is the type alias for an in-memory,
 hashmap-based externalities implementation in
-[`substrate_state_machine`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_state_machine/index.html)]
+[`substrate_state_machine`](https://substrate.dev/rustdocs/v2.0.0/sp_state_machine/index.html)]
 referred to as
-[`TestExternalities`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_state_machine/struct.TestExternalities.html).
+[`TestExternalities`](https://substrate.dev/rustdocs/v2.0.0/sp_state_machine/struct.TestExternalities.html).
 
 In the [basic mock runtime's recipe](https://substrate.dev/recipes/3-entrees/testing/mock.html), an
 `ExtBuilder` object is defined to build an instance of
-[`TestExternalities`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_io/type.TestExternalities.html).
+[`TestExternalities`](https://substrate.dev/rustdocs/v2.0.0/sp_io/type.TestExternalities.html).
 
 ```rust
 pub struct ExtBuilder;
@@ -66,7 +66,7 @@ impl ExtBuilder {
 
 To create the test environment in unit tests, the build method is called to generate a
 `TestExternalities` using the default genesis configuration. Then,
-[`with_externalities`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_externalities/fn.with_externalities.html)
+[`with_externalities`](https://substrate.dev/rustdocs/v2.0.0/sp_externalities/fn.with_externalities.html)
 provides the runtime environment in which we may call the pallet's methods to test that storage,
 events, and errors behave as expected.
 
@@ -80,12 +80,12 @@ fn fake_test_example() {
 ```
 
 Custom implementations of
-[Externalities](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_externalities/index.html) allow developers
+[Externalities](https://substrate.dev/rustdocs/v2.0.0/sp_externalities/index.html) allow developers
 to construct runtime environments that provide access to features of the outer node. Another example
 of this can be found in
-[`offchain`](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_core/offchain/index.html), which maintains its
+[`offchain`](https://substrate.dev/rustdocs/v2.0.0/sp_core/offchain/index.html), which maintains its
 own
-[Externalities](https://substrate.dev/rustdocs/v2.0.0-rc6/sp_core/offchain/trait.Externalities.html)
+[Externalities](https://substrate.dev/rustdocs/v2.0.0/sp_core/offchain/trait.Externalities.html)
 implementation.
 [Implementing configurable externalities](https://substrate.dev/recipes/3-entrees/testing/externalities.html)
 is covered in more depth in the recipes.

--- a/docs/knowledgebase/smart-contracts/contracts-pallet.md
+++ b/docs/knowledgebase/smart-contracts/contracts-pallet.md
@@ -2,7 +2,7 @@
 title: Contracts Pallet
 ---
 
-The [Contracts pallet](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_contracts/index.html) provides
+The [Contracts pallet](https://substrate.dev/rustdocs/v2.0.0/pallet_contracts/index.html) provides
 the ability for the runtime to deploy and execute [WebAssembly (Wasm)](https://webassembly.org/)
 smart contracts.
 
@@ -118,6 +118,6 @@ or upgradeable contracts on a Substrate based blockchain.
 ### References
 
 - Visit the reference docs for the
-  [Contracts module](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_contracts/index.html).
+  [Contracts module](https://substrate.dev/rustdocs/v2.0.0/pallet_contracts/index.html).
 - Take a look at the [repository for `wasmi`](https://github.com/paritytech/wasmi).
 - Take a look at the [repository for ink!](https://github.com/paritytech/ink).

--- a/docs/knowledgebase/smart-contracts/overview.md
+++ b/docs/knowledgebase/smart-contracts/overview.md
@@ -184,7 +184,7 @@ influence your decision on the kinds of situations you may want to use these dif
 ### References
 
 - Visit the reference docs for the
-  [Contracts pallet](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_contracts/index.html).
+  [Contracts pallet](https://substrate.dev/rustdocs/v2.0.0/pallet_contracts/index.html).
 - Visit the reference docs for the
-  [EVM pallet](https://substrate.dev/rustdocs/v2.0.0-rc6/pallet_evm/index.html).
+  [EVM pallet](https://substrate.dev/rustdocs/v2.0.0/pallet_evm/index.html).
 - Take a look at the [repository for ink!](https://github.com/paritytech/ink).


### PR DESCRIPTION
Use `./scripts/update-kb-rustdocs` to update.