### PR TITLE
Add guide to Init node-template with sup

### DIFF
--- a/docs/tutorials/create-your-first-substrate-chain/setup.md
+++ b/docs/tutorials/create-your-first-substrate-chain/setup.md
@@ -48,7 +48,9 @@ process is a bit harder, but well documented
 ## Compiling Substrate
 
 Once the prerequisites are installed, you can use Git to clone the Substrate Developer Hub Node
-Template, which serves as a good starting point for building on Substrate.
+Template, which serves as a good starting point for building on Substrate. Further more, you may
+want to try [sup](https://github.com/clearloop/sup) which is a substrate package manager to init
+or upgrade your Node Template in command-line.
 
 1. Clone the Node Template (version `v2.0.0`).
 


### PR DESCRIPTION
- [x] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [x] Is the writing:
  - [x] Clear: No jargon.
  - [ ] Precise: No ambiguous meanings.
  - [ ] Concise: Free of superfluous detail.
- [x] Does it follow our style guide?
- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [x] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [ ] Do links go to rustdocs or devhub articles rather than code?
- [ ] If this PR addresses an issue in the queue, have you referenced it in the description?

--- 

Hi guys, I've just written a substrate package manager named [sup](https://github.com/clearloop/sup), which can init and upgrade node-template in one command, hope somebody will like it~

```
sup 0.1.7

USAGE:
    sup <SUBCOMMAND>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

SUBCOMMANDS:
    help       Prints this message or the help of the given subcommand(s)
    new        Create a new substrate node template
    source     List Source
    tag        List available tags
    update     Update registry
    upgrade    Upgrade substrate project
```