### PR TITLE
Fix broken links

### DIFF
--- a/docs/knowledgebase/runtime/storage.md
+++ b/docs/knowledgebase/runtime/storage.md
@@ -20,11 +20,11 @@ The `storage` module in [FRAME Support](https://substrate.dev/rustdocs/v2.0.0/fr
 gives runtime developers access to Substrate's flexible storage APIs. Any value that can be encoded
 by the [Parity SCALE codec](../advanced/codec) is supported by these storage APIs:
 
-- [Storage Value](https://substrate.dev/rustdocs/v2.0.0/frame_support/storage/trait.storagevalue.html) - A single
+- [Storage Value](https://substrate.dev/rustdocs/v2.0.0/frame_support/storage/trait.StorageValue.html) - A single
   value
-- [Storage Map](https://substrate.dev/rustdocs/v2.0.0/frame_support/storage/trait.storagemap.html) - A key-value
+- [Storage Map](https://substrate.dev/rustdocs/v2.0.0/frame_support/storage/trait.StorageMap.html) - A key-value
   hash map
-- [Storage Double Map](https://substrate.dev/rustdocs/v2.0.0/frame_support/storage/trait.storagedoublemap.html) -
+- [Storage Double Map](https://substrate.dev/rustdocs/v2.0.0/frame_support/storage/trait.StorageDoubleMap.html) -
   An implementation of a map with two keys that provides the important ability to efficiently remove
   all entries that have a common first key
 


### PR DESCRIPTION
Links to StorageValue, StorageMap and StorageDoubleMap were broken.


- [ ] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [ ] Is the writing:
  - [ ] Clear: No jargon.
  - [ ] Precise: No ambiguous meanings.
  - [ ] Concise: Free of superfluous detail.
- [ ] Does it follow our style guide?
- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [ ] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [ ] Do links go to rustdocs or devhub articles rather than code?
- [ ] If this PR addresses an issue in the queue, have you referenced it in the description?
