### PR TITLE
remove sub0 registration annoucment

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -32,9 +32,6 @@ class Index extends React.Component {
 
 		return (
 			<section>
-				<div className="announcement">
-					Sub0 Online conference is back on Oct 15th! &nbsp;👉&nbsp;<a href="https://sub0.parity.io/?utm_source=substratedev&utm_medium=referral&utm_campaign=sub0&utm_term=parity">Register Here</a> 	
-				</div>
 
 				<HomeSplash
 					id='home-hero'


### PR DESCRIPTION
It is (unfortunately) over now 😭 

Possibly replace linking to the replays instead (VERY good btw 🥳 )?


