### PR TITLE
highlight substrate FRAME example

### DIFF
--- a/docs/tutorials/create-a-pallet.md
+++ b/docs/tutorials/create-a-pallet.md
@@ -289,6 +289,7 @@ four lines of code in their runtime's `Cargo.toml` files and updating their runt
   techniques.
 - For more information about runtime development tips and patterns, refer to our
   [Substrate Recipes](https://substrate.dev/recipes/).
+- For a bare FRAME pallet with higly detailed doc comments on specifics of what more you can access within FRAME, see [this example in `substrate`](https://github.com/paritytech/substrate/tree/master/frame/example)
 
 ### References
 


### PR DESCRIPTION
This is a valuable resource to get more under the hood on FRAME for those that are interested:
https://github.com/paritytech/substrate/tree/master/frame/example

This PR suggests one place to reference, I would think it might fit more in the body of the tutorial here... Open to any ideas 😁 

- [x] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [x] Is the writing:
  - [x] Clear: No jargon.
  - [x] Precise: No ambiguous meanings.
  - [x] Concise: Free of superfluous detail.
- [?] Does it follow our style guide?
- [x] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [x] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [?] Do links go to rustdocs or devhub articles rather than code?
- [x] If this PR addresses an issue in the queue, have you referenced it in the description?