### PR TITLE
Minor structural fix to chain spec article

### DIFF
--- a/docs/knowledgebase/integrate/chain-spec.md
+++ b/docs/knowledgebase/integrate/chain-spec.md
@@ -24,7 +24,7 @@ command-line flags, and the values can be changed after the blockchain has been 
 > Caution: While all properties in this section can be changed after genesis, nodes will only add
 > peers who use the same `protocolId`.
 
-### Extension
+#### Extension
 
 Because the Substrate framework is extensible, it provides a way to customize the client spec with
 additional data to configure customized parts of the client. One example use case is telling the


### PR DESCRIPTION
This PR change the `Extension` heading in the chain spec KB article from H2 to H3. This makes sense because the extension is part of the client spec. This also sidesteps the question that I had when reading the article

> If there are _two_ parts of the spec, like the text says, then why are there three subheadings.