### PR TITLE
chage broken link to proper one for jsonrpc-proxy

### DIFF
--- a/docs/tutorials/start-a-private-network/customchain.md
+++ b/docs/tutorials/start-a-private-network/customchain.md
@@ -37,9 +37,7 @@ Here are some differences from when we launched as Alice.
   the telemetry UI.
 - The optional `--rpc-methods=Unsafe` flag has been added. As the name indicates, this flag is not
   safe to use in a production setting, but it allows this tutorial to stay focused on the topic at
-  hand. In production, you should use a
-  [JSON-RPC proxy](https://github.com/paritytech/jsonrpc), but that
-  topic is out of the scope of this tutorial.
+  hand.
 
 You should see the console outputs something as follows:
 

--- a/docs/tutorials/start-a-private-network/customchain.md
+++ b/docs/tutorials/start-a-private-network/customchain.md
@@ -38,7 +38,7 @@ Here are some differences from when we launched as Alice.
 - The optional `--rpc-methods=Unsafe` flag has been added. As the name indicates, this flag is not
   safe to use in a production setting, but it allows this tutorial to stay focused on the topic at
   hand. In production, you should use a
-  [JSON-RPC proxy](../../knowledgebase/getting-started/glossary#json-rpc-proxy-crate), but that
+  [JSON-RPC proxy](https://github.com/paritytech/jsonrpc), but that
   topic is out of the scope of this tutorial.
 
 You should see the console outputs something as follows:


### PR DESCRIPTION
note: this link goes to code, but could also point directly to the docs instead: https://docs.rs/jsonrpc-core/ or https://substrate.dev/rustdocs/v2.0.0/jsonrpc_core/index.html