### PR TITLE
Fix Alice's port number

### DIFF
--- a/docs/tutorials/start-a-private-network/alicebob.md
+++ b/docs/tutorials/start-a-private-network/alicebob.md
@@ -95,7 +95,7 @@ You can tell a lot about your node by watching the output it produces in your te
 also a nice graphical user interface known as the Polkadot-JS Apps, or just "Apps" for short.
 
 In your web browser, navigate to
-[https://polkadot.js.org/apps/#/settings?rpc=ws://127.0.0.1:9944](https://polkadot.js.org/apps/#/settings?rpc=ws://127.0.0.1:9944).
+[https://polkadot.js.org/apps/#/settings?rpc=ws://127.0.0.1:9945](https://polkadot.js.org/apps/#/settings?rpc=ws://127.0.0.1:9945).
 
 > Some browsers, notably Firefox, will not connect to a local node from an https website. An easy
 > work around is to try another browser, like Chromium. Another option is to


### PR DESCRIPTION
Alices port number is explicitly set to 9945 when starting the node.


- [x] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [x] Is the writing:
  - [x] Clear: No jargon.
  - [x] Precise: No ambiguous meanings.
  - [x] Concise: Free of superfluous detail.
- [x] Does it follow our style guide?
- [x] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [x] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [x] Do links go to rustdocs or devhub articles rather than code?
- [x] If this PR addresses an issue in the queue, have you referenced it in the description?
