### PR TITLE
Resume Staging Deployment & Multilingual Update

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,9 @@ aliases:
         - master
         - staging
 
-  - &build-cmds
+  - &build-site
     run:
-      name: Building Site
+      name: Build Site
       command: |
         git config --global user.email "devhub-deploy@users.noreply.github.com"
         git config --global user.name "Devhub Deployer"
@@ -40,7 +40,7 @@ jobs:
           fingerprints:
             - "a1:f6:36:72:14:54:c0:37:47:fe:0f:c1:01:7f:21:f5"
       - checkout
-      - *build-cmds
+      - *build-site
       - run:
           name: Push to Production (Github Pages)
           command: cd website && USE_SSH=true GIT_USER=git yarn run publish-gh-pages
@@ -54,7 +54,7 @@ jobs:
           fingerprints:
             - "a1:f6:36:72:14:54:c0:37:47:fe:0f:c1:01:7f:21:f5"
       - checkout
-      - *build-cmds
+      - *build-site
       - run:
           name: Push to Staging (Heroku)
           command: scripts/deploy-staging

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,11 +23,13 @@ aliases:
         cd website && yarn install && yarn run write-translations && cd ..
         # crowdin install
         sudo apt-get update && sudo apt-get install default-jre
-        wget https://artifacts.crowdin.com/repo/deb/crowdin.deb -O crowdin.deb
+        wget https://artifacts.crowdin.com/repo/deb/crowdin3.deb -O crowdin.deb
         sudo dpkg -i crowdin.deb
         # translations upload/download
-        crowdin --config crowdin.yaml upload sources --auto-update -b master
-        crowdin --config crowdin.yaml download -b master
+        crowdin upload sources --auto-update -b master
+        crowdin download --verbose -b master
+        # also check the current translation status
+        crowdin status
 
 version: 2
 jobs:
@@ -52,7 +54,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "a1:f6:36:72:14:54:c0:37:47:fe:0f:c1:01:7f:21:f5"
+            - "6b:4c:54:91:18:12:49:6a:8e:44:f3:5e:c2:20:c2:68"
       - checkout
       - *build-site
       - run:
@@ -62,11 +64,8 @@ jobs:
   check-build:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.15.2
+      - image: circleci/node:erbium
     steps:
-      - add_ssh_keys:
-          fingerprints:
-            - "a1:f6:36:72:14:54:c0:37:47:fe:0f:c1:01:7f:21:f5"
       - checkout
       - run:
           name: Check if Site Builds

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -34,7 +34,7 @@ jobs:
   deploy-to-prod:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.15.2
+      - image: circleci/node:erbium
     steps:
       - add_ssh_keys:
           fingerprints:
@@ -48,7 +48,7 @@ jobs:
   deploy-to-staging:
     docker:
       # specify the version you desire here
-      - image: circleci/node:10.15.2
+      - image: circleci/node:erbium
     steps:
       - add_ssh_keys:
           fingerprints:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,6 +15,8 @@ We lovingly stole these guidelines from [Google's Fuchsia project](https://fuchs
 
 * [Documentation Style](#documentation-style)
 
+* [Multilingual Translation](./translation.md)
+
 ## PR Checklist
 
 - [ ] Are the audience and objective of the document clear? E.g. a document

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,5 +1,7 @@
 project_identifier_env: CROWDIN_DOCUSAURUS_PROJECT_ID
 api_key_env: CROWDIN_DOCUSAURUS_API_KEY
+project_id_env: CROWDIN_SUBSTRATEDEVHUB_ID
+api_token_env: CROWDIN_PERSONAL_TOKEN
 base_path: "./"
 preserve_hierarchy: true
 
@@ -9,40 +11,10 @@ files:
     translation: '/website/translated_docs/%locale%/**/%original_file_name%'
     languages_mapping: &anchor
       locale:
-        'af': 'af'
-        'ar': 'ar'
-        'bs-BA': 'bs-BA'
-        'ca': 'ca'
-        'cs': 'cs'
-        'da': 'da'
-        'de': 'de'
-        'el': 'el'
         'es-ES': 'es-ES'
-        'fa': 'fa-IR'
-        'fi': 'fi'
-        'fr': 'fr'
-        'he': 'he'
-        'hu': 'hu'
-        'id': 'id-ID'
-        'it': 'it'
         'ja': 'ja'
-        'ko': 'ko'
-        'mr': 'mr-IN'
-        'nl': 'nl'
-        'no': 'no-NO'
-        'pl': 'pl'
-        'pt-BR': 'pt-BR'
-        'pt-PT': 'pt-PT'
-        'ro': 'ro'
-        'ru': 'ru'
-        'sk': 'sk-SK'
-        'sr': 'sr'
-        'sv-SE': 'sv-SE'
-        'tr': 'tr'
-        'uk': 'uk'
-        'vi': 'vi'
         'zh-CN': 'zh-CN'
-        'zh-TW': 'zh-TW'
+        'zh-HK': 'zh-HK'
   -
     source: '/website/i18n/en.json'
     translation: '/website/i18n/%locale%.json'

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -17,7 +17,10 @@ files:
     source: '/website/i18n/en.json'
     translation: '/website/i18n/%locale%.json'
     languages_mapping: *anchor
-  -
-    source: '/website/versioned_docs/**/*.md'
-    translation: '/website/translated_docs/%locale%/**/%original_file_name%'
-    languages_mapping: *anchor
+
+  # note: Uncomment the following if we have `website/versioned_docs`. Otherwise, returns
+  #   error when running `crowdin upload sources` and fail the CI.
+  # -
+  #   source: '/website/versioned_docs/**/*.md'
+  #   translation: '/website/translated_docs/%locale%/**/%original_file_name%'
+  #   languages_mapping: *anchor

--- a/crowdin.yaml
+++ b/crowdin.yaml
@@ -1,5 +1,3 @@
-project_identifier_env: CROWDIN_DOCUSAURUS_PROJECT_ID
-api_key_env: CROWDIN_DOCUSAURUS_API_KEY
 project_id_env: CROWDIN_SUBSTRATEDEVHUB_ID
 api_token_env: CROWDIN_PERSONAL_TOKEN
 base_path: "./"

--- a/readme.md
+++ b/readme.md
@@ -73,6 +73,11 @@ Heroku. Note that multilingual translations are NOT pulled in.
 AND also pull in multilingual translations from our Crowdin project. The final built static site is then pushed to the
 `staging` branch and deployed to Heroku.
 
+### Multilingual Support
+
+If you are interested to contribute to multilingual translation, refer to our 
+[translation documentation](./translation.md).
+
 ### Updates
 
 There is a helper script that can be used to update `substrate.dev/rustdocs` links in the `docs/knowledgebase`

--- a/readme.md
+++ b/readme.md
@@ -73,11 +73,6 @@ Heroku. Note that multilingual translations are NOT pulled in.
 AND also pull in multilingual translations from our Crowdin project. The final built static site is then pushed to the
 `staging` branch and deployed to Heroku.
 
-### Multilingual Support
-
-If you are interested to contribute to multilingual translation, refer to our 
-[translation documentation](./translation.md).
-
 ### Updates
 
 There is a helper script that can be used to update `substrate.dev/rustdocs` links in the `docs/knowledgebase`

--- a/scripts/deploy-staging
+++ b/scripts/deploy-staging
@@ -6,7 +6,7 @@ APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
 GIT_REPO="https://github.com/substrate-developer-hub/substrate-developer-hub.github.io.git"
 PROJECT_BUILD_DIR="build/substrate-developer-hub.github.io"
 
-HTPASSWD='parity-devEx:$apr1$P.1bMHSB$u2PQ7KitD5aNk371vsQB0/'
+HTPASSWD='parity-devhub:$apr1$CJZJktOW$PEHfLAfsglPPvjnOhuIuV.'
 HTACCESS="AuthUserFile /app/.htpasswd\n
 AuthType Basic\n
 AuthName \"Restricted Access\"\n

--- a/scripts/deploy-staging
+++ b/scripts/deploy-staging
@@ -30,8 +30,8 @@ echo '<?php header("Location: /index.html");?>' > index.php
 echo $HTPASSWD > .htpasswd
 echo -e $HTACCESS > .htaccess
 
-# Everything need to be done locally should be completed by this point. Push to `staging` branch
-#   in github. Notice we have generated a keypair and set deploy key with write access in github.
+# Everything needs to be done locally should be completed by this point. Push the `staging` branch
+# in github. Notice we have generated a keypair and set to deploy keys with write access in github.
 git add .
 git commit -m "Updated"
 git push -f origin staging

--- a/scripts/deploy-staging
+++ b/scripts/deploy-staging
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# set -xe
-set -e
+set -xe
 
 APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
-GIT_REPO="https://github.com/substrate-developer-hub/substrate-developer-hub.github.io.git"
+GIT_REPO="https://github.com/jimmychu0807/devhub-maindocs.git"
 PROJECT_BUILD_DIR="build/substrate-developer-hub.github.io"
 
 HTPASSWD='parity-devhub:$apr1$CJZJktOW$PEHfLAfsglPPvjnOhuIuV.'
@@ -17,8 +16,6 @@ echo $APP_DIR
 pushd $APP_DIR > /dev/null
 
 cd website
-rm -rf $PROJECT_BUILD_DIR
-
 yarn install
 NODE_ENV=staging GIT_REV=`git rev-parse --short HEAD` yarn build
 
@@ -33,7 +30,8 @@ echo '<?php header("Location: /index.html");?>' > index.php
 echo $HTPASSWD > .htpasswd
 echo -e $HTACCESS > .htaccess
 
-# Everything need to be done locally should be completed by this point. Push to upstream.
+# Everything need to be done locally should be completed by this point. Push to `staging` branch
+#   in github. Notice we have generated a keypair and set deploy key with write access in github.
 git add .
 git commit -m "Updated"
 git push -f origin staging

--- a/translation.md
+++ b/translation.md
@@ -4,7 +4,7 @@
   
   - register a login, and send the login ID to Jimmy 
 
-- You can use the [crowdin CLI](https://github.com/crowdin/crowdin-cli/tree/3.4.0) (v3.4) to view the current translation status and download the translation to run locally. To do that, set the following two environment variables in your shell.
+- You can use the [crowdin CLI](https://github.com/crowdin/crowdin-cli/tree/3.4.0) (v3.4) to view the current translation status and download the translation to run locally. To do this, set the following two environmental variables in your shell.
 
   - `CROWDIN_SUBSTRATEDEVHUB_ID`: the project ID 
   - `CROWDIN_PERSONAL_TOKEN`: your personal crowdin token
@@ -27,7 +27,7 @@ crowdin status
 
 ## Contribute to Translation
 
-Currently we have contents partially translated to Simplified Chinese (~40%), Japanese (~30%), and Spanish (~30%), as of Nov 27th 2020. We welcome translation of all languages and particularly on the mentioned three languages. If you are interested to help, please contact us at [substrate-developer-hub@parity.io](mailto:substrate-developer-hub@parity.io) .
+Currently we have contents partially translated to Simplified Chinese (~40%), Japanese (~30%) and Spanish (~30%) as of Nov 27th 2020. We welcome translation of all languages and particularly on the mentioned languages. If you are interested in contributing please contact us at [substrate-developer-hub@parity.io](mailto:substrate-developer-hub@parity.io) .
 
 ## References:
 - [Docusaurus translation](https://docusaurus.io/docs/en/translation)

--- a/translation.md
+++ b/translation.md
@@ -1,11 +1,13 @@
 # Cheatsheet on translation work
 
-Set the two environment variable in your shell
+- Make the translation in [crowdin platform](https://crowdin.com/)
+  
+  - register a login, and send the login ID to Jimmy 
 
-- `CROWDIN_SUBSTRATEDEVHUB_ID`: the project ID 
-- `CROWDIN_PERSONAL_TOKEN`: your personal crowdin token
+- You can use the [crowdin CLI](https://github.com/crowdin/crowdin-cli/tree/3.4.0) (v3.4) to view the current translation status and download the translation to run locally. To do that, set the following two environment variables in your shell.
 
-Then you can install the [crowdin CLI](https://github.com/crowdin/crowdin-cli/tree/3.4.0) (v3.4)
+  - `CROWDIN_SUBSTRATEDEVHUB_ID`: the project ID 
+  - `CROWDIN_PERSONAL_TOKEN`: your personal crowdin token
 
 ## Usual Commands
 
@@ -24,7 +26,5 @@ crowdin status
 ```
 
 ## References:
-
 - [Docusaurus translation](https://docusaurus.io/docs/en/translation)
 - [Crowdin CLI](https://support.crowdin.com/cli-tool/)
-

--- a/translation.md
+++ b/translation.md
@@ -1,0 +1,30 @@
+# Cheatsheet on translation work
+
+Set the two environment variable in your shell
+
+- `CROWDIN_SUBSTRATEDEVHUB_ID`: the project ID 
+- `CROWDIN_PERSONAL_TOKEN`: your personal crowdin token
+
+Then you can install the [crowdin CLI](https://github.com/crowdin/crowdin-cli/tree/3.4.0) (v3.4)
+
+## Usual Commands
+
+```bash
+# To collect all strings from the project to `en.json`
+yarn docusaurus-write-translations
+
+# download the translation from crowdin platform
+crowdin download --verbose -b master
+
+# upload the source file to crowdin
+crowdin upload sources --auto-update -b master
+
+# To check current translation status
+crowdin status
+```
+
+## References:
+
+- [Docusaurus translation](https://docusaurus.io/docs/en/translation)
+- [Crowdin CLI](https://support.crowdin.com/cli-tool/)
+

--- a/translation.md
+++ b/translation.md
@@ -25,6 +25,10 @@ crowdin upload sources --auto-update -b master
 crowdin status
 ```
 
+## Contribute to Translation
+
+Currently we have contents partially translated to Simplified Chinese (~40%), Japanese (~30%), and Spanish (~30%), as of Nov 27th 2020. We welcome translation of all languages and particularly on the mentioned three languages. If you are interested to help, please contact us at [substrate-developer-hub@parity.io](mailto:substrate-developer-hub@parity.io) .
+
 ## References:
 - [Docusaurus translation](https://docusaurus.io/docs/en/translation)
 - [Crowdin CLI](https://support.crowdin.com/cli-tool/)

--- a/website/languages.js
+++ b/website/languages.js
@@ -15,10 +15,21 @@
  */
 
 const languages = [
+  // note: Please move the enabled languages to the top.
   {
     enabled: true,
     name: 'English',
     tag: 'en',
+  },
+  {
+    enabled: true,
+    name: '简体中文',
+    tag: 'zh-CN',
+  },
+  {
+    enabled: true,
+    name: '繁體中文',
+    tag: 'zh-HK'
   },
   {
     enabled: false,
@@ -146,7 +157,7 @@ const languages = [
     tag: 'ro',
   },
   {
-    enabled: true,
+    enabled: false,
     name: 'Русский',
     tag: 'ru',
   },
@@ -179,16 +190,6 @@ const languages = [
     enabled: false,
     name: 'Tiếng Việt',
     tag: 'vi',
-  },
-  {
-    enabled: true,
-    name: '中文',
-    tag: 'zh-CN',
-  },
-  {
-    enabled: false,
-    name: '繁體中文',
-    tag: 'zh-TW'
   },
 ];
 module.exports = languages;


### PR DESCRIPTION
This PR:
- updates multilingual setting, containing simplified chinese, traditional chinese, japanese, and spanish.
- updates the staging deployment flow
- crowdin cli used is updated from crowdin2 to crowdin3.
- updates readme on using crowdin and multilingual contribution


Currently, the staging site is deployed at: 
https://devhub-maindocs.herokuapp.com

*(Username and password are sent in the **devhub** element channel)*

![Screenshot 2020-11-27 at 14 09 46](https://user-images.githubusercontent.com/898091/100416772-3b303f00-30ba-11eb-8d07-e1cc173ebbd8.png)

It has the git commit hash specifying which version of source it is built from.

Currently it builds from my private repo (https://github.com/jimmychu0807/devhub-maindocs), because it requires admin access of the repo to connect to Heroku. If this PR looks good and merge to `source` branch, I will work with the admin to have Heroku connects to devhub canonical repo.