### PR TITLE
Final fix to deploy to staging of devhub-maindocs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - add_ssh_keys:
           fingerprints:
-            - "6b:4c:54:91:18:12:49:6a:8e:44:f3:5e:c2:20:c2:68"
+            - "a1:f6:36:72:14:54:c0:37:47:fe:0f:c1:01:7f:21:f5"
       - checkout
       - *build-site
       - run:

--- a/scripts/deploy-staging
+++ b/scripts/deploy-staging
@@ -2,7 +2,7 @@
 set -xe
 
 APP_DIR=$(cd $(dirname "${BASH_SOURCE[0]}")/.. && pwd)
-GIT_REPO="https://github.com/jimmychu0807/devhub-maindocs.git"
+GIT_REPO="https://github.com/substrate-developer-hub/substrate-developer-hub.github.io.git"
 PROJECT_BUILD_DIR="build/substrate-developer-hub.github.io"
 
 HTPASSWD='parity-devhub:$apr1$CJZJktOW$PEHfLAfsglPPvjnOhuIuV.'


### PR DESCRIPTION
Fix #785 

@danforbes this is the (hopefully the last) issue to fix the deployment issue. It is because the key I used is for my personal repo, not substrate-devhub repo. It is now deployed at: 

https://devhub-maindocs.herokuapp.com/index.html

Note the git commit hash in the site (on the site title) matches with the last commit in this PR.