### PR TITLE
Fix a typo for the `rpc-methods` flag

### DIFF
--- a/docs/tutorials/start-a-private-network/customchain.md
+++ b/docs/tutorials/start-a-private-network/customchain.md
@@ -24,7 +24,7 @@ The first participant can launch her node with:
   --rpc-port 9933 \
   --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
   --validator \
-  --rpc-methods=Unsafe \
+  --rpc-methods Unsafe \
   --name MyNode01
 ```
 
@@ -35,7 +35,7 @@ Here are some differences from when we launched as Alice.
 - The `--chain` flag has changed to use our custom chain spec.
 - I've added the optional `--name` flag. You may use it to give your node a human-readable name in
   the telemetry UI.
-- The optional `--rpc-methods=Unsafe` flag has been added. As the name indicates, this flag is not
+- The optional `--rpc-methods Unsafe` flag has been added. As the name indicates, this flag is not
   safe to use in a production setting, but it allows this tutorial to stay focused on the topic at
   hand.
 
@@ -159,7 +159,7 @@ parameter as Bob did previously.
   --rpc-port 9934 \
   --telemetry-url 'wss://telemetry.polkadot.io/submit/ 0' \
   --validator \
-  --rpc-methods=Unsafe \
+  --rpc-methods Unsafe \
   --name MyNode02 \
   --bootnodes /ip4/<IP Address>/tcp/<Port>/p2p/<Peer ID>
 ```


### PR DESCRIPTION
- [x] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [x] Is the writing:
  - [x] Clear: No jargon.
  - [x] Precise: No ambiguous meanings.
  - [x] Concise: Free of superfluous detail.
- [x] Does it follow our style guide?
- [x] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [x] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [x] Do links go to rustdocs or devhub articles rather than code?
- [x] If this PR addresses an issue in the queue, have you referenced it in the description?
