### PR TITLE
Hiding off-chain-indexing page for now to be expanded

### DIFF
--- a/docs/knowledgebase/runtime/fees.md
+++ b/docs/knowledgebase/runtime/fees.md
@@ -84,7 +84,7 @@ in which a target saturation level of block weight is defined. If the previous b
 saturated, then the fees are slightly increased. Similarly, if the previous block has fewer
 transactions than the target, fees are decreased by a small amount. More information about this can
 be found in the
-[Web3 research page](https://research.web3.foundation/en/latest/polkadot/Token%20Economics.html#relay-chain-transaction-fees-and-per-block-transaction-limits).
+[Web3 research page](https://w3f-research.readthedocs.io/en/latest/polkadot/economics/1-token-economics.html#relay-chain-transaction-fees-and-per-block-transaction-limits).
 
 ## Additional Fees
 
@@ -396,4 +396,4 @@ custom
 
 ### References
 
-- [Web3 Foundation Research](https://research.web3.foundation/en/latest/polkadot/Token%20Economics.html#relay-chain-transaction-fees-and-per-block-transaction-limits)
+- [Web3 Foundation Research](https://w3f-research.readthedocs.io/en/latest/polkadot/economics/1-token-economics.html#relay-chain-transaction-fees-and-per-block-transaction-limits)

--- a/website/sidebars.json
+++ b/website/sidebars.json
@@ -12,8 +12,7 @@
       "knowledgebase/learn-substrate/account-abstractions",
       "knowledgebase/learn-substrate/session-keys",
       "knowledgebase/learn-substrate/weight",
-      "knowledgebase/learn-substrate/off-chain-workers",
-      "knowledgebase/learn-substrate/off-chain-indexing"
+      "knowledgebase/learn-substrate/off-chain-workers"
     ],
     "Runtime": [
       "knowledgebase/runtime/index",


### PR DESCRIPTION
The context is here:
https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/pull/796

@tomusdrw made a great writeup on off-chain indexing, I will be expanding it tomorrow. So I want to hide the page for now.