### PR TITLE
fix github url to instructions section

### DIFF
--- a/docs/tutorials/add-a-pallet/index.md
+++ b/docs/tutorials/add-a-pallet/index.md
@@ -32,4 +32,4 @@ you do not, please complete it.
 
 > Experienced developers who truly prefer to skip those tutorials may install the Node Template
 > according to
-> [the instructions in its readme](https://github.com/substrate-developer-hub/substrate-node-template#local-development).
+> [the instructions in its readme](https://github.com/substrate-developer-hub/substrate-node-template#getting-started).


### PR DESCRIPTION
- [x] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [x] Is the writing:
  - [x] Clear: No jargon.
  - [x] Precise: No ambiguous meanings.
  - [x] Concise: Free of superfluous detail.
- [x] Does it follow our style guide?
- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [x] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [ ] Do links go to rustdocs or devhub articles rather than code?
- [ ] If this PR addresses an issue in the queue, have you referenced it in the description?
