### PR TITLE
Fix #813

### DIFF
--- a/website/pages/en/seminar.js
+++ b/website/pages/en/seminar.js
@@ -92,11 +92,8 @@ function Seminar(props) {
           <div className='row justify-content-between pt-0 faqs'>
             <div className='col-md-6 first'>
               <h4 className='mb-2'><translate>What topics are coming up?</translate></h4>
-              <p>
-                <translate>On <strong>5 Jan</strong> Dan Forbes, Parity Developer Advocate, will discuss Rust syntax for Substrate.</translate>
-                <translate>On <strong>12 Jan</strong> Parity's Master of Validators, Will Pankiewicz, will discuss network security.</translate>
-                <translate>On <strong>19 Jan</strong> Substrate Core Developer Guillaume Tholliere will discuss FRAME v2.</translate>
-              </p>
+              <p>On <strong>12 Jan</strong> Parity's Master of Validators, Will Pankiewicz, will discuss network security.</p>
+              <p>On <strong>19 Jan</strong> Substrate Core Developer Guillaume Tholliere will discuss FRAME v2.</p>
             </div>
 
             <div className='col-md-6 second'>


### PR DESCRIPTION
The reason is that `<translate>` is a docusaurus specific tag. It doesn't support having nested tag inside. So 

```html
<translate>xxx<strong>xxx</strong>xxx</translate>
```

will generate an error for that snippet. 

We can do it this way:

```html
<translate>xxx</translate><strong><translate>xxx</translate></strong><translate>xxx</translate>
```

But since this part of content changes so frequently. Let's just not translate them and keep them as plain english.