### PR TITLE
Add dependency for Ubuntu et al

### DIFF
--- a/docs/knowledgebase/getting-started/index.md
+++ b/docs/knowledgebase/getting-started/index.md
@@ -35,7 +35,7 @@ Use a terminal shell to execute the following commands:
 ```bash
 sudo apt update
 # May prompt for location information
-sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl
+sudo apt install -y cmake pkg-config libssl-dev git build-essential clang libclang-dev curl libz-dev
 ```
 
 ### Arch Linux


### PR DESCRIPTION
I just reinstalled my OS last night and needed this dependency. Without it my compiles failed with:

```
  = note: /usr/bin/ld: cannot find -lz
          collect2: error: ld returned 1 exit status
```

That message led me to https://stackoverflow.com/a/5757638/4184410

I'll leave it to you to decide whether this is generally good advice, or just some weird thing I encountered. But figured I'd share my experience.

