### PR TITLE
switch to version 2.0.1 of the node template

### DIFF
--- a/docs/tutorials/create-your-first-substrate-chain/setup.md
+++ b/docs/tutorials/create-your-first-substrate-chain/setup.md
@@ -25,10 +25,10 @@ the latest stable version you can return to these steps.
 Once the prerequisites are installed, you can use Git to clone the Substrate Developer Hub Node
 Template, which serves as a good starting point for building on Substrate.
 
-1. Clone the Node Template (version `v2.0.0`).
+1. Clone the Node Template (version `v2.0.1`).
 
     ```bash
-    git clone -b v2.0.0 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
+    git clone -b v2.0.1 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
     ```
 
 2. Initialize your WebAssembly build environment


### PR DESCRIPTION
v 2.0.0 did not compile for me on OSX 11.1 and rust 14.9 and this bump fixed it as described here https://stackoverflow.com/a/65756888/316729