### PR TITLE
Add link to contracts pallet

### DIFF
--- a/docs/knowledgebase/smart-contracts/overview.md
+++ b/docs/knowledgebase/smart-contracts/overview.md
@@ -10,7 +10,7 @@ FRAME provides two smart contract virtual machines which can be added to your Su
 
 ### Contracts Module
 
-The **FRAME Contracts pallet** (SEAL) provides functionality for the runtime to deploy and execute
+The [**FRAME Contracts pallet**](contracts-pallet) (SEAL) provides functionality for the runtime to deploy and execute
 WebAssembly smart-contracts. It is designed to iterate on the design of modern smart contract
 platforms.
 


### PR DESCRIPTION
I would also remove the (SEAL) parenthesis, since I don't see any references to SEAL anywhere in the documentation or the pallet page. Is this an old/internal name? Is SEAL an acronym for something?