### PR TITLE
Incorrect ranges

### DIFF
--- a/docs/knowledgebase/advanced/codec.md
+++ b/docs/knowledgebase/advanced/codec.md
@@ -54,10 +54,10 @@ It is encoded with the two least significant bits denoting the mode:
 - `0b01`: two-byte mode: upper six bits and the following byte is the LE encoding of the value
   (valid only for values `64-(2**14-1)`).
 - `0b10`: four-byte mode: upper six bits and the following three bytes are the LE encoding of the
-  value (valid only for values `(2**14-1)-(2**30-1)`).
+  value (valid only for values `(2**14)-(2**30-1)`).
 - `0b11`: Big-integer mode: The upper six bits are the number of bytes following, less four. The
   value is contained, LE encoded, in the bytes following. The final (most significant) byte must be
-  non-zero. Valid only for values `(2**30-1)-(2**536-1)`.
+  non-zero. Valid only for values `(2**30)-(2**536-1)`.
 
 #### Example
 


### PR DESCRIPTION
Incorrect ranges for Compact/General Integers in documentation


- [ ] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [ ] Is the writing:
  - [ ] Clear: No jargon.
  - [ ] Precise: No ambiguous meanings.
  - [ ] Concise: Free of superfluous detail.
- [ ] Does it follow our style guide?
- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [ ] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [ ] Do links go to rustdocs or devhub articles rather than code?
- [ ] If this PR addresses an issue in the queue, have you referenced it in the description?
