### PR TITLE
fixing step 5 instructions

### DIFF
--- a/docs/knowledgebase/getting-started/windows-users.md
+++ b/docs/knowledgebase/getting-started/windows-users.md
@@ -37,7 +37,7 @@ If you are trying to set up a Windows computer to build Substrate, do the follow
 
 4. Install LLVM: https://releases.llvm.org/download.html
 
-5. Install OpenSSL with `vcpkg`:
+5. Install OpenSSL with `vcpkg` using PowerShell:
 
    ```bash
    mkdir C:\Tools


### PR DESCRIPTION
The following commands will not work in windows command prompt:
```
   .\bootstrap-vcpkg.bat
   .\vcpkg.exe install openssl:x64-windows-static
```
I have updated the text to make it clear the commands should be run in Windows PowerShell


For the following issue: https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/issues/852