### PR TITLE
Adding step to install make command on Windows

### DIFF
--- a/docs/knowledgebase/getting-started/windows-users.md
+++ b/docs/knowledgebase/getting-started/windows-users.md
@@ -57,4 +57,12 @@ If you are trying to set up a Windows computer to build Substrate, do the follow
    [System.Environment]::SetEnvironmentVariable('OPENSSL_STATIC', $env:OPENSSL_STATIC, [System.EnvironmentVariableTarget]::User)
    ```
 
-7. Finally, install `cmake`: https://cmake.org/download/
+7. Install `cmake`: https://cmake.org/download/
+
+8. Install `make`
+    - This can be done using Chocolatey. First you need to install the Chocolatey package manager: https://chocolatey.org/install
+    - Once Chocolatey installed you can install make:
+
+   ```
+   choco install make
+   ```


### PR DESCRIPTION
Adding step for installing the `make` command, which is required to follow the Substrate tutorials. Without `make`, it is not possible to initialize your WebAssembly build environment or compile the node template. 

`make` is required for these commands: 
```
make init
make build
```

For this issue: https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/issues/853