### PR TITLE
Fix for issue 856

### DIFF
--- a/docs/tutorials/add-a-pallet/import-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/import-a-pallet.md
@@ -170,5 +170,5 @@ error[E0425]: cannot find function `memory_new` in module `sandbox`
 Before moving on, check that the new dependencies resolve correctly by running:
 
 ```bash
-SKIP_WASM_BUILD=1 cargo check -p node-template-runtime
+cargo check -p node-template-runtime
 ```


### PR DESCRIPTION
'SKIP_WASM_BUILD=1' is not recognized as the name of a cmdlet, function, script. This issue: https://github.com/substrate-developer-hub/substrate-developer-hub.github.io/issues/856

Getting an error when running `SKIP_WASM_BUILD=1 cargo check -p node-template-runtime` on the final step of this tutorial: https://substrate.dev/docs/en/tutorials/add-a-pallet/import-a-pallet

```
SKIP_WASM_BUILD=1 : The term 'SKIP_WASM_BUILD=1' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the 
spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ SKIP_WASM_BUILD=1 cargo check -p node-template-runtime
+ ~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (SKIP_WASM_BUILD=1:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

As far as I can see the command should just be `cargo check -p node-template-runtime` (which works). I have altered it in this pull request. 
