### PR TITLE
Command does not work on Windows

### DIFF
--- a/docs/tutorials/add-a-pallet/use-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/use-a-pallet.md
@@ -6,7 +6,7 @@ Now you are ready to compile and run your node that has been enhanced with nickn
 from the Nicks pallet. Compile the node in release mode with:
 
 ```bash
-WASM_BUILD_TOOLCHAIN=nightly-2020-10-05 cargo build --release
+cargo build --release
 ```
 
 If the build fails, go back to the previous section and make sure you followed all the steps


### PR DESCRIPTION
Running the `WASM_BUILD_TOOLCHAIN=nightly-2020-10-05 cargo build --release` command on Windows gives the following error:

```
WASM_BUILD_TOOLCHAIN=nightly-2020-10-05 : The term 'WASM_BUILD_TOOLCHAIN=nightly-2020-10-05' is not recognized as the name of a cmdlet, function, 
script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.
At line:1 char:1
+ WASM_BUILD_TOOLCHAIN=nightly-2020-10-05 cargo build --release
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : ObjectNotFound: (WASM_BUILD_TOOLCHAIN=nightly-2020-10-05:String) [], CommandNotFoundException
    + FullyQualifiedErrorId : CommandNotFoundException
```

I have suggested removing `WASM_BUILD_TOOLCHAIN=nightly-2020-10-05` so that the command is just `cargo build --release` in this pull request so that it works without the error message