### PR TITLE
removing decoded ad per Marcomms

### DIFF
--- a/website/pages/en/index.js
+++ b/website/pages/en/index.js
@@ -36,10 +36,10 @@ class Index extends React.Component {
 
     return (
       <section>
-        <div className="announcement">
+        {/* <div className="announcement">
           Polkadot Decoded 2021 - The first community curated edition.<br/> 
           <a href="https://decoded.polkadot.network/?utm_source=substrate.dev&utm_medium=referral&utm_campaign=decoded2&utm_content=notification+bar+submit+proposal">Submit your proposal now!</a>
-        </div>
+        </div> */}
         <HomeSplash
           id='home-hero'
           siteConfig={siteConfig}


### PR DESCRIPTION
Disabling top banner for two weeks to prepare for voting process.  Banner will be enabled again once the voting starts. 