### PR TITLE
toolbox tab to developer drop down

### DIFF
--- a/docs/tutorials/start-a-private-network/customchain.md
+++ b/docs/tutorials/start-a-private-network/customchain.md
@@ -84,8 +84,8 @@ GRANDPA keys are necessary for
 
 ### Option 1: Use the Polkadot-JS Apps UI
 
-You can use the Apps UI to insert your keys into the keystore. Navigate to the "Toolbox" tab and the
-"RPC Call" sub-tab. Choose "author" and "insertKey". The fields can be filled like this:
+You can use the Apps UI to insert your keys into the keystore. Navigate to "Developer --> RPC Call". Choose 
+"author" and "insertKey". The fields can be filled like this:
 
 ![Inserting a Aura key using Apps](assets/tutorials/private-network/private-network-apps-insert-key-aura.png)
 


### PR DESCRIPTION
When I run this I don't see a toolbox tab - just a Developer dropdown to get to the RPC calls - maybe the interface has changed?

![Screenshot 2021-04-01 at 12 44 22](https://user-images.githubusercontent.com/30216/113289361-03473b80-92e8-11eb-86e7-891f2ba98258.png)

maybe the screenshot in the tutorial needs changing?
