### PR TITLE
Fix private network tut page not rendering

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,16 +1,15 @@
 root = true
+
 [*]
 indent_style=space
 indent_size=2
 tab_width=2
 end_of_line=lf
+charset=utf-8
+max_line_length=100
+insert_final_newline=true
+trim_trailing_whitespace=true
 
 [*.{rs, toml}]
 indent_style=tab
 indent_size=tab
-tab_width=2
-end_of_line=lf
-charset=utf-8
-trim_trailing_whitespace=true
-max_line_length=100
-insert_final_newline=true

--- a/docs/tutorials/start-a-private-network/customchain.md
+++ b/docs/tutorials/start-a-private-network/customchain.md
@@ -47,28 +47,28 @@ Here are some differences from when we launched as Alice.
 You should see the console outputs something as follows:
 
 ```bash
-2021-03-10 18:32:15  Substrate Node    
-2021-03-10 18:32:15  ✌️  version 3.0.0-1c5b984-x86_64-linux-gnu    
-2021-03-10 18:32:15  ❤️  by Substrate DevHub <https://github.com/substrate-developer-hub>, 2017-2021    
-2021-03-10 18:32:15  📋 Chain specification: Local Testnet    
-2021-03-10 18:32:15  🏷 Node name: MyNode01    
-2021-03-10 18:32:15  👤 Role: AUTHORITY    
-2021-03-10 18:32:15  💾 Database: RocksDb at /tmp/node01/chains/local_testnet/db    
-2021-03-10 18:32:15  ⛓  Native runtime: node-template-100 (node-template-1.tx1.au1)    
-2021-03-10 18:32:16  🔨 Initializing Genesis block/state (state: 0xea47…9ba8, header-hash: 0x9d07…7cce)    
-2021-03-10 18:32:16  👴 Loading GRANDPA authority set from genesis on what appears to be first startup.    
-2021-03-10 18:32:16  ⏱  Loaded block-time = 6000 milliseconds from genesis on first-launch    
-2021-03-10 18:32:16  Using default protocol ID "sup" because none is configured in the chain specs    
-2021-03-10 18:32:16  🏷 Local node identity is: 12D3KooWJvVUoAa7R8gjCSQ45x69Ahh3HcdVSH1dvpcA52vKawHL    
-2021-03-10 18:32:16  📦 Highest known block at #0    
-2021-03-10 18:32:16  〽️ Prometheus server started at 127.0.0.1:9615    
-2021-03-10 18:32:16  Listening for new connections on 127.0.0.1:9944.    
-2021-03-10 18:32:21  💤 Idle (0 peers), best: #0 (0x9d07…7cce), finalized #0 (0x9d07…7cce), ⬇ 0 ⬆ 0    
-2021-03-10 18:32:26  💤 Idle (0 peers), best: #0 (0x9d07…7cce), finalized #0 (0x9d07…7cce), ⬇ 0 ⬆ 0  
+2021-03-10 18:32:15  Substrate Node
+2021-03-10 18:32:15  ✌️  version 3.0.0-1c5b984-x86_64-linux-gnu
+2021-03-10 18:32:15  ❤️  by Substrate DevHub <https://github.com/substrate-developer-hub>, 2017-2021
+2021-03-10 18:32:15  📋 Chain specification: Local Testnet
+2021-03-10 18:32:15  🏷 Node name: MyNode01
+2021-03-10 18:32:15  👤 Role: AUTHORITY
+2021-03-10 18:32:15  💾 Database: RocksDb at /tmp/node01/chains/local_testnet/db
+2021-03-10 18:32:15  ⛓  Native runtime: node-template-100 (node-template-1.tx1.au1)
+2021-03-10 18:32:16  🔨 Initializing Genesis block/state (state: 0xea47…9ba8, header-hash: 0x9d07…7cce)
+2021-03-10 18:32:16  👴 Loading GRANDPA authority set from genesis on what appears to be first startup.
+2021-03-10 18:32:16  ⏱  Loaded block-time = 6000 milliseconds from genesis on first-launch
+2021-03-10 18:32:16  Using default protocol ID "sup" because none is configured in the chain specs
+2021-03-10 18:32:16  🏷 Local node identity is: 12D3KooWJvVUoAa7R8gjCSQ45x69Ahh3HcdVSH1dvpcA52vKawHL
+2021-03-10 18:32:16  📦 Highest known block at #0
+2021-03-10 18:32:16  〽️ Prometheus server started at 127.0.0.1:9615
+2021-03-10 18:32:16  Listening for new connections on 127.0.0.1:9944.
+2021-03-10 18:32:21  💤 Idle (0 peers), best: #0 (0x9d07…7cce), finalized #0 (0x9d07…7cce), ⬇ 0 ⬆ 0
+2021-03-10 18:32:26  💤 Idle (0 peers), best: #0 (0x9d07…7cce), finalized #0 (0x9d07…7cce), ⬇ 0 ⬆ 0
 ```
 
 > Here you must take note of the **node identity**: `12D3KooWJvVUoAa7R8gjCSQ45x69Ahh3HcdVSH1dvpcA52vKawHL`
-> and the **IP address** `127.0.0.1` and p2p port `--port = 30333`. These values are for this specific 
+> and the **IP address** `127.0.0.1` and p2p port `--port = 30333`. These values are for this specific
 > example, but for your node, they will be different and **required** for other nodes to directly connect
 >  to it (without a bootnode in the chain spec, as we removed in the flags before)
 
@@ -84,7 +84,7 @@ GRANDPA keys are necessary for
 
 ### Option 1: Use the Polkadot-JS Apps UI
 
-You can use the Apps UI to insert your keys into the keystore. Navigate to "Developer --> RPC Call". Choose 
+You can use the Apps UI to insert your keys into the keystore. Navigate to "Developer --> RPC Call". Choose
 "author" and "insertKey". The fields can be filled like this:
 
 ![Inserting a Aura key using Apps](assets/tutorials/private-network/private-network-apps-insert-key-aura.png)
@@ -177,19 +177,16 @@ cat /tmp/node01/chains/local_testnet/keystore/617572619effc1668ca381c242885516ec
 "clip organ olive upper oak void inject side suit toilet stick narrow"
 ```
 Notice there are two keystores, as expected as we added two keys to our node.
-This example used [pair 1](keygen#pair-1) from the well known seeds here, and 
+This example used [pair 1](keygen#pair-1) from the well known seeds here, and
 will use [pair 2](keygen#pair-2) for our next node, where your keys may differ.
 
 <!-- TODO: update below with example of successful use (not working for me at time of writing) -->
 
-<!-- You can also set a non-standard keystore file for your node with the flags:
-```
---keystore-path <PATH>                                   
-            Specify custom keystore path
-
---keystore-uri <keystore-uri>                            
-            Specify custom URIs to connect to for keystore-services 
-``` -->
+<!--
+You can also set a non-standard keystore file for your node with the flags:
+  keystore-path <PATH> - Specify custom keystore path
+  keystore-uri <keystore-uri> - Specify custom URIs to connect to for keystore-services
+-->
 
 ## Subsequent Participants Join
 
@@ -199,8 +196,7 @@ parameter as Bob did previously.
 ```bash
 # purge chain (only required for new/modified dev chain spec)
 ./target/release/node-template purge-chain --base-path /tmp/node02 --chain local -y
-```
-```bash
+
 # start node02
 ./target/release/node-template \
   --base-path /tmp/node02 \
@@ -217,18 +213,18 @@ parameter as Bob did previously.
   # --bootnodes /ip4/<IP Address>/tcp/<p2p Port>/p2p/<Peer ID>
 ```
 
-> If you didn't set the correct node ID gathered from another running with the same chain spec, 
+> If you didn't set the correct node ID gathered from another running with the same chain spec,
 > but only the right IP - you will get errors of the form:
 > `💔 The bootnode you want to connect to at ... provided a different peer ID than the one you expect: ...`
 
 As before, we specify another `base-path`, give it another `name`, and also specify this node as a
 `validator`.
 
-> **Block production**: Now you *must* also set the authoring keys in this node, just as we did 
+> **Block production**: Now you *must* also set the authoring keys in this node, just as we did
 > [for the first node](#add-keys-to-keystore). Note that you will need to communicate with your node
 > on the correct `ws-port` (so setting the app UI and submitting `curl` to the right port is critical)
 > A node will not be able to produce blocks if it has not added its Aura key!
-> 
+>
 > **Block finalization**: This can *only* happen if more than two-thirds of the validators have added their
 > GRANDPA keys to their keystores. Since this network was configured with two validators (in the
 > chain spec), block finalization can occur after the second node has added its keys (i.e. 50% < 66%
@@ -237,49 +233,48 @@ As before, we specify another `base-path`, give it another `name`, and also spec
 > **Reminder:** All validators must be using *identical chain specifications* in order to peer. You should
 > see the same genesis block and state root hashes.
 
-Once the second node is running *and* it has it's authoring keys, you should see both nodes reporting block authoring:
-
+Once the second node is running *and* it has an authoring key, you should see both nodes reporting block authoring:
 
 ```bash
-2021-03-18 16:43:10  Substrate Node    
-2021-03-18 16:43:10  ✌️  version 3.0.0-c528fd2-x86_64-linux-gnu    
-2021-03-18 16:43:10  ❤️  by Substrate DevHub <https://github.com/substrate-developer-hub>, 2017-2021    
-2021-03-18 16:43:10  📋 Chain specification: Local Testnet    
-2021-03-18 16:43:10  🏷 Node name: MyNode02    
-2021-03-18 16:43:10  👤 Role: AUTHORITY    
-2021-03-18 16:43:10  💾 Database: RocksDb at /tmp/node02/chains/local_testnet/db    
-2021-03-18 16:43:10  ⛓  Native runtime: node-template-100 (node-template-1.tx1.au1)    
-2021-03-18 16:43:10  Using default protocol ID "sup" because none is configured in the chain specs    
-2021-03-18 16:43:10  🏷 Local node identity is: 12D3KooWDfpXmPtsvLCFTh4mKybYi6MvDMDiUrnRDcGZiSTR2GHp    
-2021-03-18 16:43:10  📦 Highest known block at #1    
-2021-03-18 16:43:10  Listening for new connections on 127.0.0.1:9946.    
-2021-03-18 16:43:11  🔍 Discovered new external address for our node: /ip4/127.0.0.1/tcp/30334/p2p/12D3KooWDfpXmPtsvLCFTh4mKybYi6MvDMDiUrnRDcGZiSTR2GHp    
-2021-03-18 16:43:12  🙌 Starting consensus session on top of parent 0x700fda8b9c7574553eccc8acc72e2dec59e40711e743223d67c3e5b57e1f76ef    
-2021-03-18 16:43:12  ♻️  Reorg on #1,0x700f…76ef to #2,0xe111…c084, common ancestor #0,0x2776…8ba7    
-2021-03-18 16:43:12  ✨ Imported #2 (0xe111…c084)    
-2021-03-18 16:43:12  Timeout fired waiting for transaction pool at block #1. Proceeding with production.    
-2021-03-18 16:43:12  🎁 Prepared block for proposing at 2 [hash: 0xc590a846ff17871ffdcdd670914321f667cd6ad0b898bfb6d25f7dd68fff478b; parent_hash: 0x700f…76ef; extrinsics (1): [0x34d6…ed56]]    
-2021-03-18 16:43:12  🔖 Pre-sealed block for proposal at 2. Hash now 0x38b29b343d8f6ef56286a2f3aad20c82ae75d5bb0698569dd06fca654dae6fa6, previously 0xc590a846ff17871ffdcdd670914321f667cd6ad0b898bfb6d25f7dd68fff478b.    
-2021-03-18 16:43:12  ✨ Imported #2 (0x38b2…6fa6)    
+2021-03-18 16:43:10  Substrate Node
+2021-03-18 16:43:10  ✌️  version 3.0.0-c528fd2-x86_64-linux-gnu
+2021-03-18 16:43:10  ❤️  by Substrate DevHub <https://github.com/substrate-developer-hub>, 2017-2021
+2021-03-18 16:43:10  📋 Chain specification: Local Testnet
+2021-03-18 16:43:10  🏷 Node name: MyNode02
+2021-03-18 16:43:10  👤 Role: AUTHORITY
+2021-03-18 16:43:10  💾 Database: RocksDb at /tmp/node02/chains/local_testnet/db
+2021-03-18 16:43:10  ⛓  Native runtime: node-template-100 (node-template-1.tx1.au1)
+2021-03-18 16:43:10  Using default protocol ID "sup" because none is configured in the chain specs
+2021-03-18 16:43:10  🏷 Local node identity is: 12D3KooWDfpXmPtsvLCFTh4mKybYi6MvDMDiUrnRDcGZiSTR2GHp
+2021-03-18 16:43:10  📦 Highest known block at #1
+2021-03-18 16:43:10  Listening for new connections on 127.0.0.1:9946.
+2021-03-18 16:43:11  🔍 Discovered new external address for our node: /ip4/127.0.0.1/tcp/30334/p2p/12D3KooWDfpXmPtsvLCFTh4mKybYi6MvDMDiUrnRDcGZiSTR2GHp
+2021-03-18 16:43:12  🙌 Starting consensus session on top of parent 0x700fda8b9c7574553eccc8acc72e2dec59e40711e743223d67c3e5b57e1f76ef
+2021-03-18 16:43:12  ♻️  Reorg on #1,0x700f…76ef to #2,0xe111…c084, common ancestor #0,0x2776…8ba7
+2021-03-18 16:43:12  ✨ Imported #2 (0xe111…c084)
+2021-03-18 16:43:12  Timeout fired waiting for transaction pool at block #1. Proceeding with production.
+2021-03-18 16:43:12  🎁 Prepared block for proposing at 2 [hash: 0xc590a846ff17871ffdcdd670914321f667cd6ad0b898bfb6d25f7dd68fff478b; parent_hash: 0x700f…76ef; extrinsics (1): [0x34d6…ed56]]
+2021-03-18 16:43:12  🔖 Pre-sealed block for proposal at 2. Hash now 0x38b29b343d8f6ef56286a2f3aad20c82ae75d5bb0698569dd06fca654dae6fa6, previously 0xc590a846ff17871ffdcdd670914321f667cd6ad0b898bfb6d25f7dd68fff478b.
+2021-03-18 16:43:12  ✨ Imported #2 (0x38b2…6fa6)
 2021-03-18 16:43:15  💤 Idle (1 peers), best: #2 (0xe111…c084), finalized #0 (0x2776…8ba7), ⬇ 1.4kiB/s ⬆ 1.4kiB/s
 ```
 
 The final lines shows that your node has peered with another (**`1 peers`**), and they have produced
 a block (**`best: #2 (0xe111…c084)`**)!
 
-> But do notice that even after you add the GRANDPA keys for the second node no block finalization has
+> But do notice that even after you add the GRANDPA key for the second node no block finalization has
 > happened (**`finalized #0 (0x2776…8ba7)`**).
 > **Substrate nodes require a restart after inserting a GRANDPA key.**
-> Kill your nodes and restart them with the same commands you used previously. 
+> Kill your nodes and restart them with the same commands you used previously.
 > Now blocks should be finalized!
 
 ```bash
 ...
-2021-03-18 16:47:47  💤 Idle (1 peers), best: #46 (0xfaf1…02f8), finalized #44 (0x9b08…09ea), ⬇ 1.3kiB/s ⬆ 1.3kiB/s    
-2021-03-18 16:47:48  ✨ Imported #47 (0x7375…aa51)    
-2021-03-18 16:47:52  💤 Idle (1 peers), best: #47 (0x7375…aa51), finalized #45 (0x7c13…7575), ⬇ 0.8kiB/s ⬆ 0.6kiB/s    
-2021-03-18 16:47:54  🙌 Starting consensus session on top of parent 0x73757e1773e6d86a9ef4a3ec9c3a55eef04345705c0a51f04445af657184aa51    
-2021-03-18 16:47:54  🎁 Prepared block for proposing at 48 [hash: 0xd9ef428ccd38426a47a9eca181b508630e327b35ef4c468103ce59fa861e60f6; parent_hash: 0x7375…aa51; extrinsics (1): [0x16f0…dbe6]]    
+2021-03-18 16:47:47  💤 Idle (1 peers), best: #46 (0xfaf1…02f8), finalized #44 (0x9b08…09ea), ⬇ 1.3kiB/s ⬆ 1.3kiB/s
+2021-03-18 16:47:48  ✨ Imported #47 (0x7375…aa51)
+2021-03-18 16:47:52  💤 Idle (1 peers), best: #47 (0x7375…aa51), finalized #45 (0x7c13…7575), ⬇ 0.8kiB/s ⬆ 0.6kiB/s
+2021-03-18 16:47:54  🙌 Starting consensus session on top of parent 0x73757e1773e6d86a9ef4a3ec9c3a55eef04345705c0a51f04445af657184aa51
+2021-03-18 16:47:54  🎁 Prepared block for proposing at 48 [hash: 0xd9ef428ccd38426a47a9eca181b508630e327b35ef4c468103ce59fa861e60f6; parent_hash: 0x7375…aa51; extrinsics (1): [0x16f0…dbe6]]
 2021-03-18 16:47:54  🔖 Pre-sealed block for proposal at 48. Hash now 0x23a93d8e6bbbcf9f36e61264cc3a48a426a7f1112ff48df76f0d55b52c181156, previously 0xd9ef428ccd38426a47a9eca181b508630e327b35ef4c468103ce59fa861e60f6.
 ```
 
@@ -292,12 +287,12 @@ those keypairs, and start a private network based on your custom chain spec.
 
 ### Solutions and Helpers
 
-If you would like examples of correct JSON keystore `curl` files with a known working chainspec, see the 
-[solution](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/private-chain-v3), you can use the extra files with your already cloned and compiled node, no need to 
+If you would like examples of correct JSON keystore `curl` files with a known working chainspec, see the
+[solution](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/private-chain-v3), you can use the extra files with your already cloned and compiled node, no need to
 start from scratch.
 
 <!-- TODO link to the followup tutorial about starting a 3 node network using the demo substrate node
-Details in https://github.com/substrate-developer-hub/tutorials/issues/16-->
+Details in https://github.com/substrate-developer-hub/tutorials/issues/16 -->
 
 ### Learn More
 


### PR DESCRIPTION
- close #964 
- also minor edit on `.editorconfig` (It is a good setting to have editor trimming trailing spaces on save).

@NukeManDan The reason is that within the html comment `<!-- -->`, we shouldn't have further markdown syntax, the \`\`\`...\`\`\` code block, otherwise the html parser got mixed up.