### PR TITLE
Add instructions on how to use the "key" subcommand for injecting keys

### DIFF
--- a/docs/tutorials/start-a-private-network/customchain.md
+++ b/docs/tutorials/start-a-private-network/customchain.md
@@ -155,7 +155,14 @@ If you enter the command and parameters correctly, the node will return a JSON r
 
 Make sure you delete the file that contains the keys when you are done.
 
-<!-- TODO: add option 3: use the embedded `key` CLI tool -->
+### Option 3: Use the `key` command
+
+Alternatively, you can insert a key saved to a local file using the `key` command:
+
+```bash
+# Insert the key from /path/to/key/file into the keystore
+./target/release/node-template key insert --base-path /tmp/node01 --chain local --key-type <aura/gran> --suri /path/to/key/file
+```
 
 ### Verify Keys in the Keystore (Optional)
 


### PR DESCRIPTION
Fix #791
This add explanations in the tutorial on how to insert keys using the key subcommand. Knowing this can be really helpful to inject keys before the start of the node.

- [X] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [X Is the writing:
  - [X] Clear: No jargon.
  - [X] Precise: No ambiguous meanings.
  - [X] Concise: Free of superfluous detail.
- [X] Does it follow our style guide?
- [X] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [X] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [X] Do links go to rustdocs or devhub articles rather than code?
- [X] If this PR addresses an issue in the queue, have you referenced it in the description?
