### PR TITLE
Update subkey to v2.0.1 and extend examples

### DIFF
--- a/docs/knowledgebase/getting-started/index.md
+++ b/docs/knowledgebase/getting-started/index.md
@@ -72,6 +72,18 @@ Please refer to the separate [guide for native Windows development](windows-user
 
 ## 2. Rust Developer Environment
 
+### Automated `getsubstrate.io` Script
+
+For most users you can run our script to automate the steps listed below:
+
+```bash
+curl https://getsubstrate.io -sSf | bash -s -- --fast
+```
+
+If this gives any errors, please follow the steps below to manually configure rust on your machine.
+
+### Manual Rust Configuration
+
 This guide uses [`rustup`](https://rustup.rs/) to help manage the Rust toolchain. First install and
 configure `rustup`:
 

--- a/docs/knowledgebase/integrate/subkey.md
+++ b/docs/knowledgebase/integrate/subkey.md
@@ -2,28 +2,37 @@
 title: The Subkey Tool
 ---
 
-Subkey is a key-generation utility that is developed
-[alongside Substrate](https://github.com/paritytech/substrate/tree/master/bin/utils/subkey). Its
-main features are generating key pairs (currently supporting
-[sr25519](https://wiki.polkadot.network/docs/en/learn-cryptography),
-[ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519), and
-[secp256k1](https://en.bitcoin.it/wiki/Secp256k1)), encoding SS58 addresses, and restoring keys from
-mnemonics and raw seeds. It can also create and verify signatures on a message, including encoded
-transactions.
+Subkey is a [public key cryptographic](https://en.wikipedia.org/wiki/Public-key_cryptography)
+utility that is developed
+[within Substrate itself](https://github.com/paritytech/substrate/tree/master/bin/utils/subkey). 
+Its main feature is generating and inspecting key pairs, currently supporting these scheme:
+
+- [sr25519](https://wiki.polkadot.network/docs/en/learn-cryptography_)
+- [ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519)
+- [secp256k1](https://en.bitcoin.it/wiki/Secp256k1)
+
+All keys in substrate based networks
+([like polkadot](https://wiki.polkadot.network/docs/en/learn-accounts#address-format))
+use the 
+[SS58 address encoding format](https://github.com/paritytech/substrate/wiki/External-Address-Format-(SS58))
+that is the primary user-facing way to address and interact with keys.
+
+Subkey also allows restoring keys from mnemonics and raw seeds, signing and verifying signatures
+on a message, even for encoded transactions.
 
 ## Installation
 
-### Build from Source
+### Install with Cargo
 
-The Subkey binary, `subkey`, is installed along with
-[Substrate](../getting-started/#fast-installation). If you want to play with just Subkey (and not
-Substrate), you will need to have the Substrate dependencies. Use the following two commands to
-install the dependencies and Subkey, respectively:
+You will need to have the Substrate build dependencies to install subkey.
+Use the following two commands to install the dependencies and Subkey, respectively:
 
 _Command:_
 ```bash
-curl https://getsubstrate.io -sSf | bash -s -- --fast
-cargo install --force subkey --git https://github.com/paritytech/substrate --version 2.0.0 --locked
+# Don't install substrate and subkey binary, just get deps needed with `--fast` flag
+curl https://getsubstrate.io -sSf | bash -s -- --fast 
+# Install only `subkey`, at specific version (tmp pulls files, builds, installs bin)
+cargo install --force subkey --git https://github.com/paritytech/substrate --version 2.0.1 --locked
 ```
 
 ### Compiling with Cargo
@@ -33,15 +42,57 @@ build Subkey with:
 
 _Command:_
 ```bash
+# Run this in the substrate working directory
 cargo build -p subkey --release
 ```
 
 This will generate the Subkey binary in `./target/release/subkey`. Please be aware that the
 interface to Subkey may change between versions; the commands described below have all been tested
 with the version of Subkey specified by the `cargo install` command in the
-[Build from Source](#build-from-source) section. If you follow the steps in this section to compile
-Subkey with Cargo, the version of Subkey will depend on the branch or commit of Substrate that you
-have checked out.
+[Build from Source](#build-from-source) section.
+
+> If you follow the steps in this section to compile Subkey with Cargo, the version of Subkey will
+> depend on the branch or commit of Substrate that you have checked out.
+
+Once installed, use the `subkey -h` command to see all the subcommands and flags available.
+Use `subkey <subcommand> -h` to see help items for ech subcommand.
+
+## Inspecting Keys
+
+The `inspect` command recalculates a key pair's public key and public address given its secret seed.
+You most commonly inspect the key by the mnemonic phrase that is used to derive it:
+
+_Command:_
+```bash
+subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very"
+```
+_Output:_
+```text
+Secret phrase `caution juice atom organ advance problem want pledge someone senior holiday very` is account:
+  Secret seed:       0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
+  Public key (hex):  0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  Public key (SS58): 5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR
+  Account ID:        0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  SS58 Address:      5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR
+```
+
+You can also use the secret seed directly, here the same result is seen for the secret shown above:
+
+_Command:_
+```bash
+subkey inspect 0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
+```
+_Output:_
+```text
+Secret Key URI `0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849` is account:
+  Secret seed:       0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
+  Public key (hex):  0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  Public key (SS58): 5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR
+  Account ID:        0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  SS58 Address:      5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR
+```
+
+Next in how to generate keys, we will also show you how to inspect more than a base seed. 
 
 ## Generating Keys
 
@@ -53,12 +104,17 @@ subkey generate
 ```
 _Output:_
 ```text
-Secret phrase `spend report solution aspect tilt omit market cancel what type cave author` is account:
-  Secret seed:      0x554b6fc625fbea8f56eb56262d92ccb083fd6eaaf5ee9a966eaab4db2062f4d0
-  Public key (hex): 0x143fa4ecea108937a2324d36ee4cbce3c6f3a08b0499b276cd7adb7a7631a559
-  Account ID:       0x143fa4ecea108937a2324d36ee4cbce3c6f3a08b0499b276cd7adb7a7631a559
-  SS58 Address:     5CXFinBHRrArHzmC6iYVHSSgY1wMQEdL2AiL6RmSEsFvWezd
+Secret phrase `caution juice atom organ advance problem want pledge someone senior holiday very` is account:
+  Secret seed:       0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
+  Public key (hex):  0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  Public key (SS58): 5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR
+  Account ID:        0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  SS58 Address:      5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR
 ```
+
+We will use this seed as the [example](#example-seed) for the rest of this document.
+
+---
 
 For more security, use `--words 24` (supports 12, 15, 18, 21, and 24):
 
@@ -68,15 +124,13 @@ subkey generate --words 24
 ```
 _Output:_
 ```text
-Secret phrase `enroll toss harvest pilot size end skin clog city knock bar cousin mirror journey coil used eye describe puzzle govern soup sort second cattle` is account:
-  Secret seed:      0x7590d644baa64600735ab927b6c353b9594a2cf42fe4d57c2d0e639615b37a6a
-  Public key (hex): 0xc61c17f9a3d48ff3f0700081ac7a9c92ef05758d5cc069c41247e4392eb71e00
-  Account ID:       0xc61c17f9a3d48ff3f0700081ac7a9c92ef05758d5cc069c41247e4392eb71e00
-  SS58 Address:     5GYTgcrom3pxWyHCcPPZX6iBB8xWJPARgLAng7MK4ZFaBAza
+Secret phrase `voice become refuse remove ordinary recall humble purity shock fetch open scale knee above axis blossom differ bamboo ski drip forest fade ill door` is account:
+  Secret seed:       0xed26c8119b4872da9e5c2d4b679c82a7fbbabed22cb9f61d5fd4d7806ee5b014
+  Public key (hex):  0x182a8385912e206910a11dfcfbadcc018d73ff3febe36f9eb85774e77591a314
+  Public key (SS58): 5CcPdpUAhRvGjyxcpnL7emi7SruQ98eP7mC8cDNkjCKfXNZ7
+  Account ID:        0x182a8385912e206910a11dfcfbadcc018d73ff3febe36f9eb85774e77591a314
+  SS58 Address:      5CcPdpUAhRvGjyxcpnL7emi7SruQ98eP7mC8cDNkjCKfXNZ7
 ```
-
-Subkey encodes the address depending on the network. You can use the `--network` flag to change
-this. See `subkey help` for supported networks.
 
 Use the `--scheme` option to generate an ed25519 key:
 
@@ -86,11 +140,12 @@ subkey generate --scheme ed25519
 ```
 _Output:_
 ```text
-Secret phrase `security snow crunch treat tone skill develop nominee hat slim omit stool` is account:
-  Secret seed:      0xad282c9eda80640f588f812081d98b9a2333435f76ba4ad6258e9c6f4a488363
-  Public key (hex): 0xf6a7ac42a6e1b5329bdb4e63c8bbafa5301add8102843bfe950907bd3969d944
-  Account ID:       0xf6a7ac42a6e1b5329bdb4e63c8bbafa5301add8102843bfe950907bd3969d944
-  SS58 Address:     5He7SpmVsdhoEKC5uwvPDngoCXECCeh8VrxoxnQTh1mgPiZa
+Secret phrase `voice become refuse remove ordinary recall humble purity shock fetch open scale knee above axis blossom differ bamboo ski drip forest fade ill door` is account:
+  Secret seed:       0xed26c8119b4872da9e5c2d4b679c82a7fbbabed22cb9f61d5fd4d7806ee5b014
+  Public key (hex):  0x182a8385912e206910a11dfcfbadcc018d73ff3febe36f9eb85774e77591a314
+  Public key (SS58): 5CcPdpUAhRvGjyxcpnL7emi7SruQ98eP7mC8cDNkjCKfXNZ7
+  Account ID:        0x182a8385912e206910a11dfcfbadcc018d73ff3febe36f9eb85774e77591a314
+  SS58 Address:      5CcPdpUAhRvGjyxcpnL7emi7SruQ98eP7mC8cDNkjCKfXNZ7
 ```
 
 The output gives us the following information about our key:
@@ -101,7 +156,9 @@ The output gives us the following information about our key:
   to write down your key by hand.
 - **Secret Seed** (aka "Private Key" or "Raw Seed") - The minimum necessary information to restore
   the key pair. All other information is calculated from the seed.
-- **Public Key** (aka "Account ID") - The public half of the cryptographic key pair in hexadecimal.
+- **Public Key (hex)** - The public half of the cryptographic key pair in hexadecimal.
+- **Public Key (SS58)** - The public half of the cryptographic key pair in SS58 encoding.
+- **Account ID** - Alias for the Public Key in hexadecimal. 
 - **SS58 Address** (aka "Public Address") - An SS58-encoded address based on the public key.
 
 Currently Subkey supports the following cryptographic key pairs and signing algorithms:
@@ -118,141 +175,73 @@ you will not receive a mnemonic phrase for this address.
 
 _Command:_
 ```bash
-subkey vanity --pattern joe
+subkey vanity --pattern dan
 ```
 _Output:_
 ```text
-Generating key containing pattern 'joe'
-100000 keys searched; best is 185/189 complete
-200000 keys searched; best is 187/189 complete
-300000 keys searched; best is 187/189 complete
+Generating key containing pattern 'dan'
 best: 189 == top: 189
-Secret Key URI `0x380ba96e07933b89c2b3b6d3fa98b695aab99070b8982817b74044c6fa6a375b` is account:
-  Secret seed:      0x380ba96e07933b89c2b3b6d3fa98b695aab99070b8982817b74044c6fa6a375b
-  Public key (hex): 0x4a0e48c38ae880f7eee86c8a75c6391ecb2de35adf49ee30cd1631e82de1b001
-  Account ID:       0x4a0e48c38ae880f7eee86c8a75c6391ecb2de35adf49ee30cd1631e82de1b001
-  SS58 Address:     5DjoeJSa7m4EsuSKwDN1GkrMtTiWwSMGxESQ6KSNPETPaPna
+Secret Key URI `0xf58706b2057633b6d634d9cc54e8e9e8f11246290c0bbef934129978ede6439b` is account:
+  Secret seed:       0xf58706b2057633b6d634d9cc54e8e9e8f11246290c0bbef934129978ede6439b
+  Public key (hex):  0xca043bd23428eb023d59f4b7eb37416b343fc719a3c89c5256071b4f39d73130
+  Public key (SS58): 5GdandXEVW1ER8cxW6uQgpjpyuEbZ3s2ED3ZU15LfrGdQhhz
+  Account ID:        0xca043bd23428eb023d59f4b7eb37416b343fc719a3c89c5256071b4f39d73130
+  SS58 Address:      5GdandXEVW1ER8cxW6uQgpjpyuEbZ3s2ED3ZU15LfrGdQhhz
 ```
 
-Notice the SS58 Address 5D**joe**JSa7m4EsuSKwDN1GkrMtTiWwSMGxESQ6KSNPETPaPna contains the string
-`joe`.
+Notice the SS58 Address`5GdandXEVW1ER8cxW6uQgpjpyuEbZ3s2ED3ZU15LfrGdQhhz` contains the string
+`dan`.
 
-## Password Protected Keys
+### Example Seed
 
-To generate a key that is password protected, use the `--password <password>` flag:
+> We will use the seed generated above to illustrate different
+> [HD key derivation paths](derivation-paths-from-a-seed) and
+> [passwords](#password-protected-keys):
+> ```text
+> caution juice atom organ advance problem want pledge someone senior holiday very
+> ```
 
 _Command:_
 ```bash
-subkey generate --password "pencil laptop kitchen cutter"
+subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very"
 ```
 _Output:_
 ```text
-Secret phrase `image stomach entry drink rice hen abstract moment nature broken gadget flash` is account:
-  Secret seed:      0x11353649ecfb97ed44aa4b3516c646fa49ecd3f71cc0445647a25379f848b336
-  Public key (hex): 0x1641450068c6ed825726c2a854d830352b75fb1a05e6fbcc9bc47a398a581a29
-  Account ID:       0x1641450068c6ed825726c2a854d830352b75fb1a05e6fbcc9bc47a398a581a29
-  SS58 Address:     5CZtJLXtVzrBJq1fMWfywDa6XuRwXekGdShPR4b8i9GWSbzB
+Secret phrase `caution juice atom organ advance problem want pledge someone senior holiday very` is account:
+  Secret seed:       0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
+  Public key (hex):  0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  Public key (SS58): 5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR
+  Account ID:        0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  SS58 Address:      5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR
 ```
 
-Note that the "Secret seed" is _not_ password protected and can still recover the account. The
-"Secret phrase" however, is not sufficient to recover the account without the password.
+## Specify Network Address Format
 
-## Inspecting Keys
+Subkey encodes the address depending on the network. You can use the `--network` flag to change
+this. See `subkey <inspect/generate> -n` for supported networks.
 
-The `inspect` command recalculates a key pair's public key and public address given its secret seed.
-This shows that it is sufficient to back up the seed alone.
+Let's say you want to use the **same private key** on the Kusama network. Use `--network` to get
+your **address** formatted for Kusama. Notice that the public key is the same, but the address has
+a different format. Here we use the [example seed](#example-seed):
 
 _Command:_
 ```bash
-subkey inspect 0x554b6fc625fbea8f56eb56262d92ccb083fd6eaaf5ee9a966eaab4db2062f4d0
+subkey inspect --network kusama "caution juice atom organ advance problem want pledge someone senior holiday very"
 ```
 _Output:_
 ```text
-Secret Key URI `0x554b6fc625fbea8f56eb56262d92ccb083fd6eaaf5ee9a966eaab4db2062f4d0` is account:
-  Secret seed:      0x554b6fc625fbea8f56eb56262d92ccb083fd6eaaf5ee9a966eaab4db2062f4d0
-  Public key (hex): 0x143fa4ecea108937a2324d36ee4cbce3c6f3a08b0499b276cd7adb7a7631a559
-  Account ID:       0x143fa4ecea108937a2324d36ee4cbce3c6f3a08b0499b276cd7adb7a7631a559
-  SS58 Address:     5CXFinBHRrArHzmC6iYVHSSgY1wMQEdL2AiL6RmSEsFvWezd
+Secret phrase `caution juice atom organ advance problem want pledge someone senior holiday very` is account:
+  Secret seed:       0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
+  Public key (hex):  0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  Public key (SS58): HRkCrbmke2XeabJ5fxJdgXWpBRPkXWfWHY8eTeCKwDdf4k6
+  Account ID:        0xd6a3105d6768e956e9e5d41050ac29843f98561410d3a47f9dd5b3b227ab8746
+  SS58 Address:      HRkCrbmke2XeabJ5fxJdgXWpBRPkXWfWHY8eTeCKwDdf4k6
 ```
 
-You can also inspect the key by its mnemonic phrase.
+## HD Key Derivation
 
-_Command:_
-```bash
-subkey inspect "spend report solution aspect tilt omit market cancel what type cave author"
-```
-_Output:_
-```text
-Secret phrase `spend report solution aspect tilt omit market cancel what type cave author` is account:
-  Secret seed:      0x554b6fc625fbea8f56eb56262d92ccb083fd6eaaf5ee9a966eaab4db2062f4d0
-  Public key (hex): 0x143fa4ecea108937a2324d36ee4cbce3c6f3a08b0499b276cd7adb7a7631a559
-  Account ID:       0x143fa4ecea108937a2324d36ee4cbce3c6f3a08b0499b276cd7adb7a7631a559
-  SS58 Address:     5CXFinBHRrArHzmC6iYVHSSgY1wMQEdL2AiL6RmSEsFvWezd
-```
-
-You can inspect password-protected keys either by passing the `--password` flag or using `///` at
-the end of the mnemonic:
-
-_Command (no password):_
-```bash
-subkey inspect "image stomach entry drink rice hen abstract moment nature broken gadget flash" --password "pencil laptop kitchen cutter"
-```
-_Output (no password):_
-```text
-Secret phrase `image stomach entry drink rice hen abstract moment nature broken gadget flash` is account:
-  Secret seed:      0x11353649ecfb97ed44aa4b3516c646fa49ecd3f71cc0445647a25379f848b336
-  Public key (hex): 0x1641450068c6ed825726c2a854d830352b75fb1a05e6fbcc9bc47a398a581a29
-  Account ID:       0x1641450068c6ed825726c2a854d830352b75fb1a05e6fbcc9bc47a398a581a29
-  SS58 Address:     5CZtJLXtVzrBJq1fMWfywDa6XuRwXekGdShPR4b8i9GWSbzB
-```
-
-_Command (with password):_
-```bash
-subkey inspect "image stomach entry drink rice hen abstract moment nature broken gadget flash///pencil laptop kitchen cutter"
-```
-_Output (with password):_
-```text
-Secret Key URI `image stomach entry drink rice hen abstract moment nature broken gadget flash///pencil laptop kitchen cutter` is account:
-  Secret seed:      0x11353649ecfb97ed44aa4b3516c646fa49ecd3f71cc0445647a25379f848b336
-  Public key (hex): 0x1641450068c6ed825726c2a854d830352b75fb1a05e6fbcc9bc47a398a581a29
-  Account ID:       0x1641450068c6ed825726c2a854d830352b75fb1a05e6fbcc9bc47a398a581a29
-  SS58 Address:     5CZtJLXtVzrBJq1fMWfywDa6XuRwXekGdShPR4b8i9GWSbzB
-```
-
-Let's say you want to use the same private key on Kusama network. Use `--network` to get your
-address formatted for Kusama. Notice that the public key is the same, but the address has a
-different format.
-
-_Command:_
-```bash
-subkey inspect --network kusama "spend report solution aspect tilt omit market cancel what type cave author"
-```
-_Output:_
-```text
-Secret phrase `spend report solution aspect tilt omit market cancel what type cave author` is account:
-  Secret seed:      0x554b6fc625fbea8f56eb56262d92ccb083fd6eaaf5ee9a966eaab4db2062f4d0
-  Public key (hex): 0x143fa4ecea108937a2324d36ee4cbce3c6f3a08b0499b276cd7adb7a7631a559
-  Account ID:       0x143fa4ecea108937a2324d36ee4cbce3c6f3a08b0499b276cd7adb7a7631a559
-  SS58 Address:     D2sP6XA4DBn3eadsRMYBPoggcDbCuSWUYZ5V63PifURFkcm
-```
-
-## Inserting Keys to a Node's Keystore
-
-You can insert fixed keys into a Substrate-based node's keystore with the `insert` command.
-
-_Command:_
-```bash
-# Usage
-# subkey insert [FLAGS] [OPTIONS] --key-type <key-type>
-
-# Example: Inserting an Aura key (SR25519 Crypto)
-subkey insert --suri 0x554b6fc625fbea8f56eb56262d92ccb083fd6eaaf5ee9a966eaab4db2062f4d0 --base-path /tmp/node01 --key-type aura
-
-# Example: Inserting a Grandpa key (ED25519 Crypto)
-subkey insert --suri 0x554b6fc625fbea8f56eb56262d92ccb083fd6eaaf5ee9a966eaab4db2062f4d0 --scheme ed25519 --base-path /tmp/node01 --key-type gran
-```
-
-## HD Derivation
+> REMEMBER: **Passwords and derivation paths are just as important to backup as your seed itself!**
+> See the [password note](#important-password-and-derivation-note) for more information.
 
 Subkey supports hard and soft hierarchical deterministic (HD) key derivation compliant with
 [BIP32](https://github.com/bitcoin/bips/blob/master/bip-0032.mediawiki). HD keys allow you to have a
@@ -274,15 +263,16 @@ You can derive a hard key child using `//` after the mnemonic phrase:
 
 _Command:_
 ```bash
-subkey inspect "spend report solution aspect tilt omit market cancel what type cave author//joe//polkadot//0"
+subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very//polkadot//0"
 ```
 _Output:_
 ```text
-Secret Key URI `spend report solution aspect tilt omit market cancel what type cave author//joe//polkadot//0` is account:
-  Secret seed:      0xc25dda466c7749ac966b95e2ef8f5e758a063d26ac4d1895f479964aaf5679cc
-  Public key (hex): 0xb49bdb8f2aa714b6e8b62426d03a1506878fc1f2937bdd396bc2102c95613f4b
-  Account ID:       0xb49bdb8f2aa714b6e8b62426d03a1506878fc1f2937bdd396bc2102c95613f4b
-  SS58 Address:     5G9Wmx3mgRk7yKWPs421ZVuz1W34KxjKi3NDo7rVtdPMc6ju
+Secret Key URI `caution juice atom organ advance problem want pledge someone senior holiday very//polkadot//0` is account:
+  Secret seed:       0x056a6a4e203766ffbea3146967ef25e9daf677b14dc6f6ed8919b1983c9bebbc
+  Public key (hex):  0x841226ea070c9577979ca2e854130fbe3253853c13c05943e09908312950275d
+  Public key (SS58): 5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repo5EYjQX
+  Account ID:        0x841226ea070c9577979ca2e854130fbe3253853c13c05943e09908312950275d
+  SS58 Address:      5F3sa2TJAWMqDhXG6jhV4N8ko9SxwGy8TpaNS1repo5EYjQX
 ```
 
 ### Soft Key Derivation
@@ -291,126 +281,167 @@ Likewise, you can derive a soft key child using a single `/` after the mnemonic 
 
 _Command:_
 ```bash
-subkey inspect "spend report solution aspect tilt omit market cancel what type cave author/joe/polkadot/0"
+subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very/polkadot/0"
 ```
 _Output:_
 ```text
-Secret Key URI `spend report solution aspect tilt omit market cancel what type cave author/joe/polkadot/0` is account:
-  Secret seed:      n/a
-  Public key (hex): 0x06382e496cb8b1664501bbfcc8205c7b1ddc2402e32ef0479b18abdf326ca342
-  Account ID:       0x06382e496cb8b1664501bbfcc8205c7b1ddc2402e32ef0479b18abdf326ca342
-  SS58 Address:     5CCrqJffST8uh8RLn2sFJwg1JWs4HkKL88xmdZRdnHt8GDyA
+Secret Key URI `caution juice atom organ advance problem want pledge someone senior holiday very/polkadot/0` is account:
+  Secret seed:       n/a
+  Public key (hex):  0x94bec5342b23d74b8736c74ab1bf311182c62510d220313a424e63ea57172855
+  Public key (SS58): 5FRjccB7s9fbMu4pwQhYng2quQnKYkCHXRUCMBRwL7Pzj8FX
+  Account ID:        0x94bec5342b23d74b8736c74ab1bf311182c62510d220313a424e63ea57172855
+  SS58 Address:      5FRjccB7s9fbMu4pwQhYng2quQnKYkCHXRUCMBRwL7Pzj8FX
 ```
 
-Recall the SS58 address from the same seed phrase,
-`5CXFinBHRrArHzmC6iYVHSSgY1wMQEdL2AiL6RmSEsFvWezd`. We can use that to derive the same child
-address.
+Recall the _root_ SS58 address from the [example seed](#example-seed) is,
+`5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR`. We can use that _public address_ to derive the 
+same child address as above using the _seed_.
 
 _Command:_
 ```bash
-subkey inspect "5CXFinBHRrArHzmC6iYVHSSgY1wMQEdL2AiL6RmSEsFvWezd/joe/polkadot/0"
+subkey inspect "5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR/polkadot/0"
 ```
 _Output:_
 ```text
-Public Key URI `5CXFinBHRrArHzmC6iYVHSSgY1wMQEdL2AiL6RmSEsFvWezd/joe/polkadot/0` is account:
+Public Key URI `5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR/polkadot/0` is account:
   Network ID/version: substrate
-  Public key (hex):   0x06382e496cb8b1664501bbfcc8205c7b1ddc2402e32ef0479b18abdf326ca342
-  Account ID:         0x06382e496cb8b1664501bbfcc8205c7b1ddc2402e32ef0479b18abdf326ca342
-  SS58 Address:       5CCrqJffST8uh8RLn2sFJwg1JWs4HkKL88xmdZRdnHt8GDyA
+  Public key (hex):   0x94bec5342b23d74b8736c74ab1bf311182c62510d220313a424e63ea57172855
+  Public key (SS58):  5FRjccB7s9fbMu4pwQhYng2quQnKYkCHXRUCMBRwL7Pzj8FX
+  Account ID:         0x94bec5342b23d74b8736c74ab1bf311182c62510d220313a424e63ea57172855
+  SS58 Address:       5FRjccB7s9fbMu4pwQhYng2quQnKYkCHXRUCMBRwL7Pzj8FX
 ```
 
-Note that the two addresses here match. This is not the case in hard key derivation.
+Note that the two addresses here match. This is not the case in hard key derivation!
 
-### Putting it All Together
+## Password Protected Keys
+
+> REMEMBER: **Passwords and derivation paths are just as important to backup as your seed itself!**
+> See the [password note](#important-password-and-derivation-note) for more information.
+
+To generate a key that is password protected, use the `--password <password>` flag:
+
+_Command:_
+```bash
+subkey generate --password "pencil laptop kitchen cutter"
+```
+_Output:_
+```text
+Secret phrase `apology truck manage valve merge front idea imitate coconut poverty trap gas` is account:
+  Secret seed:       0x2da5ddf709c8cd6c9727d347cd1e867234802d15ce51581d86bcb949bba7bcb5
+  Public key (hex):  0xc8e06268df6173a32a859da4b9601d5e11b503206f9817ae1c101d2984826d19
+  Public key (SS58): 5Gc66BfkkebMv3EvP8ThfpiGLng1EPtUiAQ71gzwpJosJqvo
+  Account ID:        0xc8e06268df6173a32a859da4b9601d5e11b503206f9817ae1c101d2984826d19
+  SS58 Address:      5Gc66BfkkebMv3EvP8ThfpiGLng1EPtUiAQ71gzwpJosJqvo
+```
+You can inspect password-protected keys either by passing the `--password` flag or using `///` at
+the end of the mnemonic:
+
+_Command (--password flag):_
+```bash
+subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very" --password "pencil laptop kitchen cutter"
+```
+_Output (--password flag):_
+```text
+Secret phrase `caution juice atom organ advance problem want pledge someone senior holiday very` is account:
+  Secret seed:       0xdfc5d5d5235a37fdc907ee1cb720299f96aeb02f9c7c2fcad7ee8c7bfbd2a4db
+  Public key (hex):  0xdef8f78b123475265815b65a7c55e105e1ab185f4969954f68d92b7bb67a1045
+  Public key (SS58): 5H74SqH1iQCWh5Gumyghh1WJMcmM6TdBHYSK7mKVJbv9NuSK
+  Account ID:        0xdef8f78b123475265815b65a7c55e105e1ab185f4969954f68d92b7bb67a1045
+  SS58 Address:      5H74SqH1iQCWh5Gumyghh1WJMcmM6TdBHYSK7mKVJbv9NuSK
+```
+
+_Command (password with `///`):_
+```bash
+subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very///pencil laptop kitchen cutter"
+```
+_Output (password with `///`):_
+```text
+Secret Key URI `caution juice atom organ advance problem want pledge someone senior holiday very///pencil laptop kitchen cutter` is account:
+  Secret seed:       0xdfc5d5d5235a37fdc907ee1cb720299f96aeb02f9c7c2fcad7ee8c7bfbd2a4db
+  Public key (hex):  0xdef8f78b123475265815b65a7c55e105e1ab185f4969954f68d92b7bb67a1045
+  Public key (SS58): 5H74SqH1iQCWh5Gumyghh1WJMcmM6TdBHYSK7mKVJbv9NuSK
+  Account ID:        0xdef8f78b123475265815b65a7c55e105e1ab185f4969954f68d92b7bb67a1045
+  SS58 Address:      5H74SqH1iQCWh5Gumyghh1WJMcmM6TdBHYSK7mKVJbv9NuSK
+```
+Take note that the `--password` flag _does not_ report the password used, but the `///` _does_. 
+The output is identical otherwise.
+
+## Combine Derivation Paths & Passwords
+
+### IMPORTANT PASSWORD AND DERIVATION NOTE
+
+> Note that the "Secret seed" is the same and _not_ password protected, it can still recover _an_
+> account - but the key pair derived _is not the same_ account as recovered with _any_ password!
+> You can see this in the next section demonstrated.
+> 
+> **The "Secret phrase" is not sufficient to recover the account without the password!**
+> Keep this password secure, as without it your key pair cannot be recovered!
 
 You can mix and match hard and soft key paths (although it doesn't make much sense to have hard
 paths as children of soft paths). For example:
 
 _Command:_
 ```bash
-subkey inspect "spend report solution aspect tilt omit market cancel what type cave author//joe//polkadot/0"
+subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very//polkadot/0"
 ```
 _Output:_
 ```text
-Secret Key URI `spend report solution aspect tilt omit market cancel what type cave author//joe//polkadot/0` is account:
-  Secret seed:      n/a
-  Public key (hex): 0x2c6d81f231fb2ee802e11a81e5d88c1dfaae2b945b66177bd041d4ef474bb70c
-  Account ID:       0x2c6d81f231fb2ee802e11a81e5d88c1dfaae2b945b66177bd041d4ef474bb70c
-  SS58 Address:     5D4xVeDs9osZBjZ72in3hGvqRvDaWh63sw2xBdAS589m3BHG
+Secret Key URI `caution juice atom organ advance problem want pledge someone senior holiday very//polkadot/0` is account:
+  Secret seed:       n/a
+  Public key (hex):  0xd6f066a07b3ebb1572c00506c9dc86a64db63779e7791e7d37247f59e4bffc14
+  Public key (SS58): 5GvXX2NpiR8qoeTUbdzTCmMtZgGrZxRoCJFEvfL1iaDjTFKb
+  Account ID:        0xd6f066a07b3ebb1572c00506c9dc86a64db63779e7791e7d37247f59e4bffc14
+  SS58 Address:      5GvXX2NpiR8qoeTUbdzTCmMtZgGrZxRoCJFEvfL1iaDjTFKb
 ```
 
-The first two levels (`//joe//polkadot`) are hard-derived, while the leaf (`/0`) is soft-derived.
+The first level (`//polkadot`) is **hard-derived**, while the leaf (`/0`) is **soft-derived**.
 
 To use key derivation with a password-protected key, add your password to the end:
 
 _Command:_
 ```bash
 # mnemonic phrase plus derivation path plus password
-subkey inspect "image stomach entry drink rice hen abstract moment nature broken gadget flash/joe/polkadot/0///pencil laptop kitchen cutter"
+subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very//polkadot/0///pencil laptop kitchen cutter"
 ```
 _Output:_
 ```text
-Secret Key URI `image stomach entry drink rice hen abstract moment nature broken gadget flash/joe/polkadot/0///pencil laptop kitchen cutter` is account:
-  Secret seed:      n/a
-  Public key (hex): 0xc69291081743ba7e8f587f1e848d1ffc7b634ce21793a231b7ac75d430b59068
-  Account ID:       0xc69291081743ba7e8f587f1e848d1ffc7b634ce21793a231b7ac75d430b59068
-  SS58 Address:     5GZ4srnepXvdsuNVoxCGyVZd8ScDm4gkGLTKuaGARy9akjTa
+Secret Key URI `caution juice atom organ advance problem want pledge someone senior holiday very//polkadot/0///pencil laptop kitchen cutter` is account:
+  Secret seed:       n/a
+  Public key (hex):  0xcaf1f5ec14b507b5c365c6528cc06de74a5615274694a0c895ed4109c0ff0d32
+  Public key (SS58): 5GeoQa3nkeNmzZSfgBFuK3BkAggnTHcX3S1j94sffJYYphrP
+  Account ID:        0xcaf1f5ec14b507b5c365c6528cc06de74a5615274694a0c895ed4109c0ff0d32
+  SS58 Address:      5GeoQa3nkeNmzZSfgBFuK3BkAggnTHcX3S1j94sffJYYphrP
 ```
+
+Notice that for **soft-derived** keys, you can use the hard-derived (with optional password)
+**parent's public address** to derive new public addresses:
 
 _Command:_
 ```bash
-# SS58-address plus derivation path
-subkey inspect "5CZtJLXtVzrBJq1fMWfywDa6XuRwXekGdShPR4b8i9GWSbzB/joe/polkadot/0"
+# A soft-derived SS58-address for a *public address* with a hidden seed, hard derivation path, and password
+subkey inspect "5GsbzysSK8TKahXBC7FpS2myx3nWehMyYU7q8CLrzZCjpKbM/0"
 ```
 _Output:_
 ```text
-Public Key URI `5CZtJLXtVzrBJq1fMWfywDa6XuRwXekGdShPR4b8i9GWSbzB/joe/polkadot/0` is account:
+Public Key URI `5GsbzysSK8TKahXBC7FpS2myx3nWehMyYU7q8CLrzZCjpKbM/0` is account:
   Network ID/version: substrate
-  Public key (hex):   0xc69291081743ba7e8f587f1e848d1ffc7b634ce21793a231b7ac75d430b59068
-  Account ID:         0xc69291081743ba7e8f587f1e848d1ffc7b634ce21793a231b7ac75d430b59068
-  SS58 Address:       5GZ4srnepXvdsuNVoxCGyVZd8ScDm4gkGLTKuaGARy9akjTa
+  Public key (hex):   0xcaf1f5ec14b507b5c365c6528cc06de74a5615274694a0c895ed4109c0ff0d32
+  Public key (SS58):  5GeoQa3nkeNmzZSfgBFuK3BkAggnTHcX3S1j94sffJYYphrP
+  Account ID:         0xcaf1f5ec14b507b5c365c6528cc06de74a5615274694a0c895ed4109c0ff0d32
+  SS58 Address:       5GeoQa3nkeNmzZSfgBFuK3BkAggnTHcX3S1j94sffJYYphrP
 ```
 
 Notice that the "SS58-address plus derivation path" produces the same address as the "mnemonic
-phrase plus derivation path plus password." As such, you can reveal your parent address and
-derivation paths without revealing your mnemonic phrase or password, retaining control of all
-derived addresses.
-
-## Well-Known Keys
-
-If you've worked with Substrate previously, you have likely encountered the ubiquitous accounts for
-Alice, Bob, and their friends. These keys are not at all private, but are useful for playing with
-Substrate without always generating new key pairs. You can inspect these "well-known" keys as well.
-
-_Command:_
-```bash
-subkey inspect //Alice
-```
-_Output:_
-```text
-Secret Key URI `//Alice` is account:
-  Secret seed:      0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a
-  Public key (hex): 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
-  Account ID:       0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
-  SS58 Address:     5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
-```
-
-A mnemonic phrase is a secret group of words that can be used to uniquely generate a private key. In
-Subkey, there is a specific dev phrase used whenever a mnemonic phrase is omitted.`//Alice` for
-example is actually:
-
-`bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice`
-
-It is important remember that keys such as this are _not_ secure, and should be deployed only for
-testing. In addition, anyone not using PolkadotJS or Subkey should note this information to properly
-generate the account.
+phrase plus derivation path plus password." As such, you can reveal your parent public address
+and soft derivation paths without revealing your mnemonic phrase or password, retaining control
+of all derived addresses.
 
 ## Signing and Verifying Messages
 
 ### Signing
 
 You can sign a message by passing the message to Subkey on STDIN. You can sign with either your seed
-or mnemonic phrase.
+or mnemonic phrase. We use the [example raw seed and address](#example-seed) here:
 
 _Command:_
 ```bash
@@ -418,11 +449,11 @@ _Command:_
 # echo "msg" | subkey sign --suri <secret-seed>
 
 # Example
-echo "test message" | subkey sign --suri 0x554b6fc625fbea8f56eb56262d92ccb083fd6eaaf5ee9a966eaab4db2062f4d0
+echo "test message" | subkey sign --suri 0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
 ```
 _Output:_
 ```text
-1e298698ed97654189ed082b3a19634c9cc2743e6e2e4089cc1759c959a8226d7709916041e195dd861a556ca1fde3d4305c00be3f08f72d369b83b9e3fa9b87
+22f91b41ba12f8663ddce26bfc90dbfe6a51683fd3782ad679ab2a5fdbe7d44c2a119f22c74eea22555e5483eb7f42b828f189a38379d59c3b607d2461f0858e
 ```
 
 ### Verifying
@@ -435,7 +466,7 @@ _Command:_
 # echo "msg" | subkey verify <signature> <SS58-address>
 
 # Example
-echo "test message" | subkey verify 1e298698ed97654189ed082b3a19634c9cc2743e6e2e4089cc1759c959a8226d7709916041e195dd861a556ca1fde3d4305c00be3f08f72d369b83b9e3fa9b87 5CXFinBHRrArHzmC6iYVHSSgY1wMQEdL2AiL6RmSEsFvWezd
+echo "test message" | subkey verify 22f91b41ba12f8663ddce26bfc90dbfe6a51683fd3782ad679ab2a5fdbe7d44c2a119f22c74eea22555e5483eb7f42b828f189a38379d59c3b607d2461f0858e 5Gv8YYFu8H1btvmrJy9FjjAWfb99wrhV3uhPFoNEr918utyR
 ```
 _Output:_
 ```text
@@ -460,16 +491,130 @@ subkey generate-node-key --file node-key
 ```
 _Output:_
 ```text
-Qmb8aDXsAMoCnozJmUSaYzDTTxathFrsSU12A4owZ5K6V3
+12D3KooWAhzqC4xstZKkAVYge2Q9tAMcnFhNEabLejRNVoQWLHHC
 ```
 
 The peer ID is displayed on screen and the actual key is saved in the `<output-file>`.
 
-## More Subkey to Explore
+<!-- FIXME! The `insert` command is _only_ for the key subcommand embedded in nodes. Not for subkey - we need to point this out... -->
+<!-- 
+## Inserting Keys to a Node's Keystore
+
+You can insert fixed keys into a Substrate-based node's keystore with the `insert` command. It is common to use the
+same secret, but with different scheme for substrate key use:
+
+_Command (Sr25519 - AURA key):_
+```bash
+node key inspect "caution juice atom organ advance problem want pledge someone senior holiday very" --scheme sr25519
+```
+_Output:_
+```bash
+Secret phrase `caution juice atom organ advance problem want pledge someone senior holiday very` is account:
+  Secret seed:       0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
+  Public key (hex):  0xbd7436a22571207d018ffe83f5dc77d0750b7777f1eb169053d40201d6c68d53
+  Public key (SS58): 5GM7RtekqU8cGiS4MKQ7tufoH4Q1itzmoFpVcvcPfjksyPrw
+  Account ID:        0xbd7436a22571207d018ffe83f5dc77d0750b7777f1eb169053d40201d6c68d53
+  SS58 Address:      5GM7RtekqU8cGiS4MKQ7tufoH4Q1itzmoFpVcvcPfjksyPrw
+```
+
+---
+
+_Command (Ed25519 - GRANDPA key):_
+```bash
+node key inspect "caution juice atom organ advance problem want pledge someone senior holiday very" --scheme ed25519
+```
+_Output:_
+```bash
+Secret phrase `caution juice atom organ advance problem want pledge someone senior holiday very` is account:
+  Secret seed:       0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
+  Public key (hex):  0xbd7436a22571207d018ffe83f5dc77d0750b7777f1eb169053d40201d6c68d53
+  Public key (SS58): 5GM7RtekqU8cGiS4MKQ7tufoH4Q1itzmoFpVcvcPfjksyPrw
+  Account ID:        0xbd7436a22571207d018ffe83f5dc77d0750b7777f1eb169053d40201d6c68d53
+  SS58 Address:      5GM7RtekqU8cGiS4MKQ7tufoH4Q1itzmoFpVcvcPfjksyPrw
+```
+
+---
+
+_Command (ECDSA - BEEFY key):_
+```bash
+node key inspect "caution juice atom organ advance problem want pledge someone senior holiday very" --scheme ecdsa
+```
+_Output:_
+```bash
+Secret phrase `caution juice atom organ advance problem want pledge someone senior holiday very` is account:
+  Secret seed:       0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849
+  Public key (hex):  0x03b2217d2c348df72c4789947291e2e63ba7798baebaa937f40fd5d68f022dd4b4
+  Public key (SS58): KWCjsULBCExp8BTVhVjVjWrqMYxSi4a1CRyU2tyzNiAs4mLk8
+  Account ID:        0x9bd03f5c43588e0e8110463dde4122bce1279d683de87e95975f7c717f00d617
+  SS58 Address:      5Fb19AznKQqtHLf82PfMXKwWPqAWPB9g7fW6AhP8BVJ8Soqo
+```
+
+---
+
+Now you can use the `insert` subcommand to save these keys approriately for use by your node, all
+we require is the base path, key type, and correct scheme used to do so with a given secret URI:
+
+_Command:_
+```bash
+# Usage
+# node key insert [FLAGS] [OPTIONS] --key-type <key-type>
+
+# Example: Inserting an Aura key (SR25519 Crypto)
+node key insert --suri 0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849 --base-path /tmp/node01 --key-type aura
+
+# Example: Inserting a Grandpa key (ED25519 Crypto)
+node key insert --suri 0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849 --scheme ed25519 --base-path /tmp/node01 --key-type gran
+
+# Example: Inserting a Beefy key (ECDSA Crypto)
+node key insert --suri 0xc8fa03532fb22ee1f7f6908b9c02b4e72483f0dbd66e4cd456b8f34c6230b849 --scheme ecdsa --base-path /tmp/node01 --key-type beefy
+```
+-->
+
+## Well-Known Keys
+
+> The common seed used for all development accounts is:
+> ```text
+> bottom drive obey lake curtain smoke basket hold race lonely fit walk
+> ```
+> Various development accounts are _derived_ from this seed.
+
+If you've worked with Substrate previously, you have likely encountered the ubiquitous accounts for
+Alice, Bob, and their friends. These keys are not at all private, but are useful for playing with
+Substrate without always generating new key pairs. You can inspect these "well-known" keys as well.
+
+_Command:_
+```bash
+subkey inspect //Alice
+```
+_Output:_
+```text
+Secret Key URI `//Alice` is account:
+  Secret seed:      0xe5be9a5092b81bca64be81d212e7f2f9eba183bb7a90954f7b76361f6edb5c0a
+  Public key (hex): 0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+  Account ID:       0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d
+  SS58 Address:     5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY
+```
+
+A mnemonic phrase is a secret group of words that can be used to uniquely generate a private key. In
+Subkey, there is a specific dev phrase used whenever a mnemonic phrase is omitted.`//Alice` for
+example is actually:
+
+```text
+bottom drive obey lake curtain smoke basket hold race lonely fit walk//Alice
+```
+
+It is important remember that keys such as this are _not_ secure, and should be deployed only for
+testing. In addition, anyone not using PolkadotJS or Subkey should note this information to properly
+generate the account.
+
+## Further Resources
+
+> REMEMBER: **Passwords and derivation paths are just as important to backup as your seed itself!**
+> See the [password note](#important-password-and-derivation-note) for more information.
 
 - Learn more by running `subkey help` or see the
   [README](https://github.com/paritytech/substrate/tree/master/bin/utils/subkey).
 - Key pairs can also be generated in the [PolkadotJS Apps UI](https://polkadot.js.org/apps/). Try
   creating keys with the UI and restoring them with Subkey or vice versa.
 - Learn more about
-  [different cryptographies and choosing between them](https://wiki.polkadot.network/docs/en/learn-cryptography).
+  [different cryptographic algorithms and choosing between them](https://wiki.polkadot.network/docs/en/learn-cryptography).

--- a/docs/knowledgebase/integrate/subkey.md
+++ b/docs/knowledgebase/integrate/subkey.md
@@ -54,8 +54,8 @@ with the version of Subkey specified by the `cargo install` command in the
 > If you follow the steps in this section to compile Subkey with Cargo, the version of Subkey will
 > depend on the branch or commit of Substrate that you have checked out.
 
-Once installed, use the `subkey -h` command to see all the subcommands and flags available.
-Use `subkey <subcommand> -h` to see help items for ech subcommand.
+Once installed, use the `subkey -h` command to see all the sub-commands and flags available.
+Use `subkey <sub-command> -h` to see help items for ech sub-command.
 
 ## Inspecting Keys
 
@@ -496,7 +496,7 @@ _Output:_
 
 The peer ID is displayed on screen and the actual key is saved in the `<output-file>`.
 
-<!-- FIXME! The `insert` command is _only_ for the key subcommand embedded in nodes. Not for subkey - we need to point this out... -->
+<!-- FIXME! The `insert` command is _only_ for the key sub-command embedded in nodes. Not for subkey - we need to point this out... -->
 <!-- 
 ## Inserting Keys to a Node's Keystore
 
@@ -551,7 +551,7 @@ Secret phrase `caution juice atom organ advance problem want pledge someone seni
 
 ---
 
-Now you can use the `insert` subcommand to save these keys approriately for use by your node, all
+Now you can use the `insert` sub-command to save these keys appropriately for use by your node, all
 we require is the base path, key type, and correct scheme used to do so with a given secret URI:
 
 _Command:_

--- a/docs/knowledgebase/integrate/subkey.md
+++ b/docs/knowledgebase/integrate/subkey.md
@@ -11,25 +11,25 @@ Its main feature is generating and inspecting key pairs, currently supporting th
 - [ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519)
 - [secp256k1](https://en.bitcoin.it/wiki/Secp256k1)
 
-All keys in substrate based networks
+All keys in Substrate based networks
 ([like polkadot](https://wiki.polkadot.network/docs/en/learn-accounts#address-format))
 use the 
 [SS58 address encoding format](https://github.com/paritytech/substrate/wiki/External-Address-Format-(SS58))
-that is the primary user-facing way to address and interact with keys.
+that is the primary user-facing way to interact with keys.
 
-Subkey also allows restoring keys from mnemonics and raw seeds, signing and verifying signatures
-on a message, even for encoded transactions.
+Subkey also allows restoring keys from mnemonics and raw seeds; signing and verifying signatures
+on a message; and signing and verifying signatures for encoded transactions.
 
 ## Installation
 
 ### Install with Cargo
 
-You will need to have the Substrate build dependencies to install subkey.
+You will need to have the Substrate build dependencies to install Subkey.
 Use the following two commands to install the dependencies and Subkey, respectively:
 
 _Command:_
 ```bash
-# Don't install substrate and subkey binary, just get deps needed with `--fast` flag
+# Use the `--fast` flag to get the dependencies without needing to install the Substrate and Subkey binary
 curl https://getsubstrate.io -sSf | bash -s -- --fast 
 # Install only `subkey`, at specific version (tmp pulls files, builds, installs bin)
 cargo install --force subkey --git https://github.com/paritytech/substrate --version 2.0.1 --locked
@@ -42,7 +42,7 @@ build Subkey with:
 
 _Command:_
 ```bash
-# Run this in the substrate working directory
+# Run this in the Substrate working directory
 cargo build -p subkey --release
 ```
 
@@ -240,7 +240,7 @@ Secret phrase `caution juice atom organ advance problem want pledge someone seni
 
 ## HD Key Derivation
 
-> REMEMBER: **Passwords and derivation paths are just as important to backup as your seed itself!**
+> **Remember that passwords and derivation paths are just as important to backup as the seed itself!**
 > See the [password note](#important-password-and-derivation-note) for more information.
 
 Subkey supports hard and soft hierarchical deterministic (HD) key derivation compliant with
@@ -315,7 +315,7 @@ Note that the two addresses here match. This is not the case in hard key derivat
 
 ## Password Protected Keys
 
-> REMEMBER: **Passwords and derivation paths are just as important to backup as your seed itself!**
+> **Remember that passwords and derivation paths are just as important to backup as the seed itself!**
 > See the [password note](#important-password-and-derivation-note) for more information.
 
 To generate a key that is password protected, use the `--password <password>` flag:
@@ -370,9 +370,9 @@ The output is identical otherwise.
 
 ### IMPORTANT PASSWORD AND DERIVATION NOTE
 
-> Note that the "Secret seed" is the same and _not_ password protected, it can still recover _an_
-> account - but the key pair derived _is not the same_ account as recovered with _any_ password!
-> You can see this in the next section demonstrated.
+> Note that the "secret seed" is the same and _is not_ password protected. Although it can still recover _an_
+> account, the key pair that's derived _is not the same_ account as recovered with _any_ password!
+> This is demonstrated in the next section.
 > 
 > **The "Secret phrase" is not sufficient to recover the account without the password!**
 > Keep this password secure, as without it your key pair cannot be recovered!
@@ -400,7 +400,7 @@ To use key derivation with a password-protected key, add your password to the en
 
 _Command:_
 ```bash
-# mnemonic phrase plus derivation path plus password
+# Mnemonic phrase + derivation path + password
 subkey inspect "caution juice atom organ advance problem want pledge someone senior holiday very//polkadot/0///pencil laptop kitchen cutter"
 ```
 _Output:_
@@ -431,8 +431,8 @@ Public Key URI `5GsbzysSK8TKahXBC7FpS2myx3nWehMyYU7q8CLrzZCjpKbM/0` is account:
   SS58 Address:       5GeoQa3nkeNmzZSfgBFuK3BkAggnTHcX3S1j94sffJYYphrP
 ```
 
-Notice that the "SS58-address plus derivation path" produces the same address as the "mnemonic
-phrase plus derivation path plus password." As such, you can reveal your parent public address
+Notice that the "SS58-address + derivation path" produces the same address as the "mnemonic
+phrase + derivation path + password." As such, you can reveal your parent public address
 and soft derivation paths without revealing your mnemonic phrase or password, retaining control
 of all derived addresses.
 

--- a/docs/knowledgebase/integrate/subkey.md
+++ b/docs/knowledgebase/integrate/subkey.md
@@ -161,15 +161,6 @@ The output gives us the following information about our key:
 - **Account ID** - Alias for the Public Key in hexadecimal. 
 - **SS58 Address** (aka "Public Address") - An SS58-encoded address based on the public key.
 
-Currently Subkey supports the following cryptographic key pairs and signing algorithms:
-
-- `sr25519`: Schorr signatures on the Ristretto group
-- `ed25519`: ed25519
-- `secp256k1`: ECDSA signatures on secp256k1
-
-Note that the address for a secp256k1 key is the SS58 encoding of the hash of the public key in
-order to reduce the public key from 33 bytes to 32 bytes.
-
 You can also create a vanity address, meaning an address that contains a specified sub-string. But
 you will not receive a mnemonic phrase for this address.
 

--- a/docs/knowledgebase/integrate/subkey.md
+++ b/docs/knowledgebase/integrate/subkey.md
@@ -31,7 +31,7 @@ _Command:_
 ```bash
 # Use the `--fast` flag to get the dependencies without needing to install the Substrate and Subkey binary
 curl https://getsubstrate.io -sSf | bash -s -- --fast 
-# Install only `subkey`, at specific version (tmp pulls files, builds, installs bin)
+# Install only `subkey`, at a specific version
 cargo install --force subkey --git https://github.com/paritytech/substrate --version 2.0.1 --locked
 ```
 

--- a/docs/knowledgebase/integrate/subkey.md
+++ b/docs/knowledgebase/integrate/subkey.md
@@ -7,7 +7,7 @@ utility that is developed
 [within Substrate itself](https://github.com/paritytech/substrate/tree/master/bin/utils/subkey). 
 Its main feature is generating and inspecting key pairs, currently supporting these scheme:
 
-- [sr25519](https://wiki.polkadot.network/docs/en/learn-cryptography_)
+- [sr25519](https://wiki.polkadot.network/docs/en/learn-cryptography)
 - [ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519)
 - [secp256k1](https://en.bitcoin.it/wiki/Secp256k1)
 
@@ -195,7 +195,7 @@ Notice the SS58 Address`5GdandXEVW1ER8cxW6uQgpjpyuEbZ3s2ED3ZU15LfrGdQhhz` contai
 ### Example Seed
 
 > We will use the seed generated above to illustrate different
-> [HD key derivation paths](derivation-paths-from-a-seed) and
+> [HD key derivation paths](#hd-key-derivation) and
 > [passwords](#password-protected-keys):
 > ```text
 > caution juice atom organ advance problem want pledge someone senior holiday very

--- a/docs/knowledgebase/integrate/subkey.md
+++ b/docs/knowledgebase/integrate/subkey.md
@@ -362,12 +362,12 @@ The output is identical otherwise.
 
 ### IMPORTANT PASSWORD AND DERIVATION NOTE
 
-> Note that the "secret seed" is the same and _is not_ password protected. Although it can still recover _an_
+> Note that the "secret seed" _is not_ password protected. Although it can still recover _an_
 > account, the key pair that's derived _is not the same_ account as recovered with _any_ password!
-> This is demonstrated in the next section.
-> 
-> **The "Secret phrase" is not sufficient to recover the account without the password!**
-> Keep this password secure, as without it your key pair cannot be recovered!
+> The same seed with different derivation paths passwords will derive **different keys**!
+>
+> **The "Secret phrase" is not sufficient to recover a key pair!**
+> Keep your paths and passwords secure, as without it your key pair cannot be recovered!
 
 You can mix and match hard and soft key paths (although it doesn't make much sense to have hard
 paths as children of soft paths). For example:

--- a/docs/knowledgebase/integrate/subkey.md
+++ b/docs/knowledgebase/integrate/subkey.md
@@ -7,9 +7,10 @@ utility that is developed
 [within Substrate itself](https://github.com/paritytech/substrate/tree/master/bin/utils/subkey). 
 Its main feature is generating and inspecting key pairs, currently supporting these scheme:
 
-- [sr25519](https://wiki.polkadot.network/docs/en/learn-cryptography)
-- [ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519)
-- [secp256k1](https://en.bitcoin.it/wiki/Secp256k1)
+- [sr25519](https://wiki.polkadot.network/docs/en/learn-cryptography): Schorr signatures on
+  the Ristretto group
+- [ed25519](https://en.wikipedia.org/wiki/EdDSA#Ed25519): SHA-512 (SHA-2) on Curve25519
+- [secp256k1](https://en.bitcoin.it/wiki/Secp256k1): ECDSA signatures on secp256k1
 
 All keys in Substrate based networks
 ([like polkadot](https://wiki.polkadot.network/docs/en/learn-accounts#address-format))

--- a/docs/knowledgebase/runtime/fees.md
+++ b/docs/knowledgebase/runtime/fees.md
@@ -84,7 +84,7 @@ in which a target saturation level of block weight is defined. If the previous b
 saturated, then the fees are slightly increased. Similarly, if the previous block has fewer
 transactions than the target, fees are decreased by a small amount. More information about this can
 be found in the
-[Web3 research page](https://w3f-research.readthedocs.io/en/latest/polkadot/overview/2-token-economics.html?highlight=token%20economics#relay-chain-transaction-fees-and-per-block-transaction-limits).
+[Web3 research page](https://w3f-research.readthedocs.io/en/latest/polkadot/overview/2-token-economics.html#relay-chain-transaction-fees-and-per-block-transaction-limits).
 
 ## Additional Fees
 

--- a/website/pages/en/tutorials.js
+++ b/website/pages/en/tutorials.js
@@ -80,16 +80,15 @@ const TutorialCards = props => {
 
 class Tutorials extends React.Component {
   render() {
-    // self-note: This part need to be added in render() function, and cannot be put at the top
-    //   of the file, as `<translate>` tag need to be called everytime it is rendered based on
-    //   currently selected translation.
+    // dev-note: This part need to be added in render() function, and cannot be put at the top
+    // of the file, as `<translate>` tag need to be called every time it is rendered based on
+    // currently selected translation.
     const tutorialCardData = [
       {
         title: <translate>Create Your First Substrate Chain</translate>,
         text: (
           <translate>
-            Launch and interact with your first Substrate chain in this minimal
-            end-to-end guide.
+            Launch and interact with your first Substrate chain in this minimal end-to-end guide.
           </translate>
         ),
         difficulty: <translate>Easy</translate>,
@@ -101,11 +100,7 @@ class Tutorials extends React.Component {
       {
         img: "img/tutorials/crates.png",
         title: <translate>Add a Pallet to Your Runtime</translate>,
-        text: (
-          <translate>
-            Add the Nicks pallet to your Substrate node template.
-          </translate>
-        ),
+        text: <translate>Add the Nicks pallet to your Substrate node template.</translate>,
         difficulty: <translate>Easy</translate>,
         length: <translate>2 Hours</translate>,
         prerequisite: true,
@@ -116,9 +111,7 @@ class Tutorials extends React.Component {
         img: "img/tutorials/first-substrate-chain.png",
         title: <translate>Build a PoE Decentralized Application</translate>,
         text: (
-          <translate>
-            Build a customized Substrate chain with its own user interface.
-          </translate>
+          <translate>Build a customized Substrate chain with its own user interface.</translate>
         ),
         difficulty: <translate>Easy</translate>,
         length: <translate>1 Hour</translate>,
@@ -131,8 +124,7 @@ class Tutorials extends React.Component {
         title: <translate>Start a Private Network with Substrate</translate>,
         text: (
           <translate>
-            Learn to start a blockchain network using an out-of-the-box
-            Substrate node.
+            Learn to start a blockchain network using an out-of-the-box Substrate node.
           </translate>
         ),
         difficulty: <translate>Easy</translate>,
@@ -146,8 +138,7 @@ class Tutorials extends React.Component {
         title: <translate>Write a Pallet in its Own Crate</translate>,
         text: (
           <translate>
-            Make your pallets re-usable by packaging them in their own rust
-            crate.
+            Make your pallets re-usable by packaging them in their own rust crate.
           </translate>
         ),
         difficulty: <translate>Medium</translate>,
@@ -159,9 +150,7 @@ class Tutorials extends React.Component {
       {
         title: <translate>Forkless Upgrade a Chain</translate>,
         text: (
-          <translate>
-            Perform a forkless runtime upgrade on a running Substrate network.
-          </translate>
+          <translate>Perform a forkless runtime upgrade on a running Substrate network.</translate>
         ),
         difficulty: <translate>Medium</translate>,
         length: <translate>2 Hours</translate>,
@@ -174,8 +163,8 @@ class Tutorials extends React.Component {
         title: <translate>Build a Permissioned Network</translate>,
         text: (
           <translate>
-            A comprehensive, end-to-end tutorial for building a permissioned
-            network using node-authorization pallet.
+            A comprehensive, end-to-end tutorial for building a permissioned network using
+            node-authorization pallet.
           </translate>
         ),
         difficulty: <translate>Easy</translate>,
@@ -187,11 +176,7 @@ class Tutorials extends React.Component {
       {
         img: "img/tutorials/crates.png",
         title: <translate>Add the Contracts Pallet to a Runtime</translate>,
-        text: (
-          <translate>
-            Add the Contracts pallet to your Substrate node template.
-          </translate>
-        ),
+        text: <translate>Add the Contracts pallet to your Substrate node template.</translate>,
         difficulty: <translate>Medium</translate>,
         length: <translate>2 Hours</translate>,
         prerequisite: true,
@@ -203,8 +188,7 @@ class Tutorials extends React.Component {
         title: <translate>ink! Smart Contracts Tutorial</translate>,
         text: (
           <translate>
-            A comprehensive, end-to-end tutorial for building an ERC20 token
-            contract using ink!.
+            A comprehensive, end-to-end tutorial for building an ERC20 token contract using ink!.
           </translate>
         ),
         difficulty: <translate>Easy</translate>,
@@ -219,8 +203,7 @@ class Tutorials extends React.Component {
         title: <translate>Substrate Frontier Workshop</translate>,
         text: (
           <translate>
-            A workshop to configure Substrate node to run Substrate EVM and
-            Solidity contracts.
+            A workshop to configure Substrate node to run Substrate EVM and Solidity contracts.
           </translate>
         ),
         difficulty: <translate>Medium</translate>,
@@ -235,8 +218,7 @@ class Tutorials extends React.Component {
         title: <translate>Visualizing Node Metrics</translate>,
         text: (
           <translate>
-            Learn how to visualize the metrics that Substrate records using
-            Prometheus.
+            Learn how to visualize the metrics that Substrate records using Prometheus.
           </translate>
         ),
         difficulty: <translate>Easy</translate>,
@@ -272,26 +254,36 @@ class Tutorials extends React.Component {
     const { baseUrl, docsUrl } = siteConfig;
     const docsPart = `${docsUrl ? `${docsUrl}/` : ""}`;
     const langPart = `${language ? `${language}/` : ""}`;
-    const docUrlHandler = url => (url.startsWith('http://') || url.startsWith('https://'))
-      ? url
-      : `${baseUrl}${docsPart}${langPart}${url}`;
+    const docUrlHandler = (url) =>
+      url.startsWith("http://") || url.startsWith("https://")
+        ? url
+        : `${baseUrl}${docsPart}${langPart}${url}`;
 
-    const baseUrlHandler = url => (url.startsWith('http://') || url.startsWith('https://'))
-      ? url
-      : `${baseUrl}${url}`;
+    const baseUrlHandler = (url) =>
+      url.startsWith("http://") || url.startsWith("https://") ? url : `${baseUrl}${url}`;
 
-    return <div>
-      <HomeSplash
-        siteConfig={siteConfig}
-        language={language}
-        title={<translate>Tutorial Catalog</translate>}
-        tagline={<translate>Let's learn together!</translate>}
-        padding={0}
-      />
-      <div className="mainContainer"><Container><Row>
-        <TutorialCards baseUrl={baseUrlHandler} docUrl={docUrlHandler} data={ tutorialCardData } />
-      </Row></Container></div>
-    </div>;
+    return (
+      <div>
+        <HomeSplash
+          siteConfig={siteConfig}
+          language={language}
+          title={<translate>Tutorial Catalog</translate>}
+          tagline={<translate>Let's learn together!</translate>}
+          padding={0}
+        />
+        <div className="mainContainer">
+          <Container>
+            <Row>
+              <TutorialCards
+                baseUrl={baseUrlHandler}
+                docUrl={docUrlHandler}
+                data={tutorialCardData}
+              />
+            </Row>
+          </Container>
+        </div>
+      </div>
+    );
   }
 }
 


### PR DESCRIPTION
Closes #984

Note: subkey cannot `insert` keys, only the embedded `key` sub-command in substrate nodes is able to now. 
