### PR TITLE
Windows Installation: Don't download vcpkg full git history

### DIFF
--- a/docs/knowledgebase/getting-started/windows-users.md
+++ b/docs/knowledgebase/getting-started/windows-users.md
@@ -50,7 +50,7 @@ If you do decide to try and use a Windows computer to _natively_ build Substrate
    ```bash
    mkdir C:\Tools
    cd C:\Tools
-   git clone https://github.com/Microsoft/vcpkg.git
+   git clone https://github.com/Microsoft/vcpkg.git --depth=1
    cd vcpkg
    .\bootstrap-vcpkg.bat
    .\vcpkg.exe install openssl:x64-windows-static


### PR DESCRIPTION
Downloading entire history of git repo is unnecessary just
to install vcpkg. So we only download recent branch.

* This PR is very simple so i am not filling all the templates. 