### PR TITLE
Update tutorial to match Nicks balances weight type implimentation

### DIFF
--- a/docs/tutorials/add-a-pallet/configure-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/configure-a-pallet.md
@@ -104,7 +104,8 @@ impl pallet_balances::Config for Runtime {
     type AccountStore = System;
 
     // No weight information is supplied to the Balances pallet by the Node Template's runtime.
-    type WeightInfo = ();
+    // type WeightInfo = (); // old way
+    type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 
     // The ubiquitous event type.
     type Event = Event;

--- a/docs/tutorials/add-a-pallet/configure-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/configure-a-pallet.md
@@ -103,7 +103,7 @@ impl pallet_balances::Config for Runtime {
     // The FRAME runtime system is used to track the accounts that hold balances.
     type AccountStore = System;
 
-    // No weight information is supplied to the Balances pallet by the Node Template's runtime.
+    // Weight information is supplied to the Balances pallet by the Node Template's runtime.
     // type WeightInfo = (); // old way
     type WeightInfo = pallet_balances::weights::SubstrateWeight<Runtime>;
 


### PR DESCRIPTION
Weight information for is specified as pallet_balances::weights::SubstrateWeight<Runtime> in code for Balances at runtime/src/lib.rs (Line 249), not () as stated in this current tutorial file. This appears to be a fairly recent change, and is not reflected in either v1 or v2 of the Nicks pallet as shown currently here: https://substrate.dev/docs/en/knowledgebase/runtime/pallets
This might be confusing comparing the pallet_balances implementation and pallet_nicks with a known difference. The wording or comparison may also be affected.

This is the file referenced in the tutorial for verification:

https://github.com/substrate-developer-hub/substrate-node-template/blob/master/runtime/src/lib.rs

Other references in the file, specifically impl pallet_grandpa and impl palet_timestamp both specify the suggested WeightInfo = (); - see lines 220 and 232 in runtime/src/lib.rs.

There's probably a better way to do this. I just wanted to mention to see if that was old news. 
