### PR TITLE
Added a note on migration order in runtime upgrade

### DIFF
--- a/docs/knowledgebase/runtime/upgrades.md
+++ b/docs/knowledgebase/runtime/upgrades.md
@@ -156,9 +156,21 @@ order, if needed (see an
 FRAME storage migrations will run in this order:
 
 1. `frame_system::on_runtime_upgrade`
-1. Custom `on_runtime_upgrade`, as described above
-1. All `on_runtime_upgrade` functions defined in the pallets included in the runtime, in the order
+2. Custom `on_runtime_upgrade`, as described above
+3. All `on_runtime_upgrade` functions defined in the pallets included in the runtime, in the order
    described above
+
+> **Note**
+>
+> If you are running on Substrate version after [commit `#bd8c1cae`](https://github.com/paritytech/substrate/commit/bd8c1cae434dd6050833555e14967e3cd936e004), the storage migration order has been updated
+> to:
+>
+> 1. Custom `on_runtime_upgrade`
+> 2. `frame_system::on_runtime_upgrade`
+> 3. All `on_runtime_upgrade` functions defined in all included pallets.
+>
+> The reason is to cater for scenarios where one need to write custom code to make the
+> `frame_system::on_runtime_upgrade` runs and returns successfully. Refer to the detail [here](https://github.com/paritytech/substrate/issues/8683).
 
 ### Testing Migrations
 

--- a/docs/knowledgebase/runtime/upgrades.md
+++ b/docs/knowledgebase/runtime/upgrades.md
@@ -162,15 +162,15 @@ FRAME storage migrations will run in this order:
 
 > **Note**
 >
-> If you are running on Substrate version after [commit `#bd8c1cae`](https://github.com/paritytech/substrate/commit/bd8c1cae434dd6050833555e14967e3cd936e004), the storage migration order has been updated
+> If you are running on a Substrate version after [commit `#bd8c1cae`](https://github.com/paritytech/substrate/commit/bd8c1cae434dd6050833555e14967e3cd936e004), the storage migration order has been updated
 > to:
 >
 > 1. Custom `on_runtime_upgrade`
 > 2. `frame_system::on_runtime_upgrade`
 > 3. All `on_runtime_upgrade` functions defined in all included pallets.
 >
-> The reason is to cater for scenarios where one need to write custom code to make the
-> `frame_system::on_runtime_upgrade` runs and returns successfully. Refer to the detail [here](https://github.com/paritytech/substrate/issues/8683).
+> The reason is to cater for scenarios where one needs to write custom code to make
+> `frame_system::on_runtime_upgrade` run and return successfully. Refer to the details [here](https://github.com/paritytech/substrate/issues/8683).
 
 ### Testing Migrations
 


### PR DESCRIPTION
@apopiak 
Ref https://github.com/paritytech/substrate/pull/8687#issuecomment-831189692