### PR TITLE
Fix a typo in add-a-pallet tutorial

### DIFF
--- a/docs/tutorials/add-a-pallet/configure-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/configure-a-pallet.md
@@ -194,10 +194,10 @@ construct_runtime!(
         UncheckedExtrinsic = UncheckedExtrinsic
     {
         /* --snip-- */
-        Balances: pallet_balances::{Pallet, Call, Storage, Config<T>, Event<T>},
+        Balances: pallet_balances::{Module, Call, Storage, Config<T>, Event<T>},
 
         /*** Add This Line ***/
-        Nicks: pallet_nicks::{Pallet, Call, Storage, Event<T>},
+        Nicks: pallet_nicks::{Module, Call, Storage, Event<T>},
     }
 );
 ```


### PR DESCRIPTION
The [solution](https://github.com/substrate-developer-hub/substrate-node-template/blob/tutorials/solutions/add-a-pallet-v3/runtime/src/lib.rs#L284) is `Module` while the doc says `Pallet`.