### PR TITLE
Fix the FRAME link in Pallets documentation.

### DIFF
--- a/docs/knowledgebase/runtime/pallets.md
+++ b/docs/knowledgebase/runtime/pallets.md
@@ -19,7 +19,7 @@ target use case. The result: each pallet has its own discrete logic which can mo
 functionality of your blockchain's state transition functions.
 
 
-For example, the [Balances pallet](https://github.com/paritytech/substrate/tree/master/frame/balances), which is included in [FRAME](/knowledgebase/runtime/frame), defines cryptocurrency capabilities for your blockchain. More specifically, it
+For example, the [Balances pallet](https://github.com/paritytech/substrate/tree/master/frame/balances), which is included in [FRAME](../../knowledgebase/runtime/frame), defines cryptocurrency capabilities for your blockchain. More specifically, it
 defines: 
 - **Storage items** that keep track of the tokens a user owns.
 - **Functions** that users can call to transfer


### PR DESCRIPTION
#1065 Fix the FRAME link in the Runtime Developmen/Pallets documentation.

- [ ] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [ ] Is the writing:
  - [ ] Clear: No jargon.
  - [ ] Precise: No ambiguous meanings.
  - [ ] Concise: Free of superfluous detail.
- [ ] Does it follow our style guide?
- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [x] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [x] Do links go to rustdocs or devhub articles rather than code?
- [x] If this PR addresses an issue in the queue, have you referenced it in the description?
