### PR TITLE
Fix 3 links in Pallets documentation, Add Contracts Pallet tutorial and Add Pallet tutorial.

### DIFF
--- a/docs/knowledgebase/runtime/pallets.md
+++ b/docs/knowledgebase/runtime/pallets.md
@@ -19,7 +19,7 @@ target use case. The result: each pallet has its own discrete logic which can mo
 functionality of your blockchain's state transition functions.
 
 
-For example, the [Balances pallet](https://github.com/paritytech/substrate/tree/master/frame/balances), which is included in [FRAME](/knowledgebase/runtime/frame), defines cryptocurrency capabilities for your blockchain. More specifically, it
+For example, the [Balances pallet](https://github.com/paritytech/substrate/tree/master/frame/balances), which is included in [FRAME](../../knowledgebase/runtime/frame), defines cryptocurrency capabilities for your blockchain. More specifically, it
 defines: 
 - **Storage items** that keep track of the tokens a user owns.
 - **Functions** that users can call to transfer

--- a/docs/tutorials/add-a-pallet/publish-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/publish-a-pallet.md
@@ -52,7 +52,7 @@ in **crates.io** repository.
 
 ## Learn More
 
-- We have [plenty of tutorials](../tutorials) to showcase Substrate development concepts and
+- We have [plenty of tutorials](/tutorials) to showcase Substrate development concepts and
   techniques.
 - For more information about runtime development tips and patterns, refer to our
   [Substrate Recipes](https://substrate.dev/recipes).

--- a/docs/tutorials/add-contracts-pallet.md
+++ b/docs/tutorials/add-contracts-pallet.md
@@ -553,7 +553,7 @@ runtime. You can basically copy what was done there to your own runtime.
 
 ### Learn More
 
-- [A minimalist tutorial on writing your runtime pallet in its own package](../../tutorials/create-a-pallet/).
+- [A minimalist tutorial on writing your runtime pallet in its own package](../../tutorials/build-a-dapp/pallet).
 - With your node now capable of running smart contracts, go learn about
   [Substrate ink! smart contracts](../../knowledgebase/smart-contracts/).
 - [Substrate Recipes](https://substrate.dev/recipes/) offers detailed tutorials about writing


### PR DESCRIPTION
#1065 Fix the FRAME link in the Runtime Development/Pallets documentation.

#1067 Fix the Custom Pallet Development link in the Add Contracts Pallet tutorial.

#1068 Fix the Tutorials link in the Add Pallet / Publish Your Own Pallet tutorial.

- [ ] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [ ] Is the writing:
  - [ ] Clear: No jargon.
  - [ ] Precise: No ambiguous meanings.
  - [ ] Concise: Free of superfluous detail.
- [ ] Does it follow our style guide?
- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [x] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [x] Do links go to rustdocs or devhub articles rather than code?
- [x] If this PR addresses an issue in the queue, have you referenced it in the description?
