### PR TITLE
Make the tutorial work from a remote host

### DIFF
--- a/docs/tutorials/create-your-first-substrate-chain/interact.md
+++ b/docs/tutorials/create-your-first-substrate-chain/interact.md
@@ -144,6 +144,14 @@ the results of asynchronous operations. If you have already used the Front-End T
 balance transfer as described above, you should see an event for the transfer in the Event component
 next to the Pallet Interactor.
 
+## Troubleshooting
+
+In case of this error `Error Connecting to Substrate { "isTrusted": true }` and if you run the node as a remote host, you can create ssh local port forwarding to access the Front-End Template at http://localhost:8000/:
+```bash
+# Enable local port forwarding on port 9944
+ssh -L 9944:127.0.0.1:9944 <remote user>@<remote host ip> -N -f
+```
+
 ## Next Steps
 
 🎉 Congratulations!!! 🎉


### PR DESCRIPTION
I've added a Troubleshooting section to explain how to access the Front-End Template http://localhost:8000 without having the error `Error Connecting to Substrate { "isTrusted": true }` when the node is running on a remote host.
The issue has been raised here: https://github.com/substrate-developer-hub/substrate-front-end-template/issues/186


- [ ] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [ ] Is the writing:
  - [ ] Clear: No jargon.
  - [ ] Precise: No ambiguous meanings.
  - [ ] Concise: Free of superfluous detail.
- [ ] Does it follow our style guide?
- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [ ] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [ ] Do links go to rustdocs or devhub articles rather than code?
- [ ] If this PR addresses an issue in the queue, have you referenced it in the description?
