### PR TITLE
add additional behaviour at installation errors

### DIFF
--- a/docs/knowledgebase/getting-started/index.md
+++ b/docs/knowledgebase/getting-started/index.md
@@ -93,6 +93,12 @@ For most users you can run our script to automate the steps listed below:
 curl https://getsubstrate.io -sSf | bash -s -- --fast
 ```
 
+if you receive an error as "Skipped cargo install of 'substrate' and 'subkey'" just run the script above without --fast (solved bug see - [substrate bug 3890](https://github.com/paritytech/substrate/issues/3890))
+```bash
+curl https://getsubstrate.io -sSf | bash -s --
+```
+
+
 If this gives any errors, please follow the steps below to manually configure rust on your machine.
 
 ### Manual Rust Configuration


### PR DESCRIPTION
some errors occurred and can be solved while removing --fast option (as in substrate bug 3890 mentioned)


- [x] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [x] Is the writing:
  - [x] Clear: No jargon.
  - [x] Precise: No ambiguous meanings.
  - [x] Concise: Free of superfluous detail.
- [x] Does it follow our style guide?
- [x] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
