### PR TITLE
Update parity-db version

### DIFF
--- a/docs/tutorials/create-your-first-substrate-chain/setup.md
+++ b/docs/tutorials/create-your-first-substrate-chain/setup.md
@@ -28,11 +28,15 @@ Template, which serves as a good starting point for building on Substrate.
     ```bash
     git clone -b v3.0.0+monthly-2021-05 --depth 1 https://github.com/substrate-developer-hub/substrate-node-template
     ```
-2. Compile the Node Template
+2. Compile the Node Template and update to the latest parity database
 
     ```bash
     cd substrate-node-template
     # NOTE: you should always use the `--release` flag
+    
+    cargo update -p parity-db
+    # TIP: this updates parity-db to v0.2.4
+    
     cargo build --release
     # ^^ this will take a while!
     ```


### PR DESCRIPTION
The parity-db version prevents the following error from being thrown:
 failed to parse manifest at `/home/ubuntu/.cargo/registry/src/github.com-1ecc6299db9ec823/parity-db-0.2.3/Cargo.toml`

```sh 
    $ cargo update -p parity-db
    Updating crates.io index
    Updating parity-db v0.2.3 -> v0.2.4
```


- [ ] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [ ] Is the writing:
  - [ ] Clear: No jargon.
  - [ ] Precise: No ambiguous meanings.
  - [ ] Concise: Free of superfluous detail.
- [ ] Does it follow our style guide?
- [ ] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [ ] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [ ] Do links go to rustdocs or devhub articles rather than code?
- [ ] If this PR addresses an issue in the queue, have you referenced it in the description?
