### PR TITLE
usize => u32 to make nicks tutorial work again.

### DIFF
--- a/docs/tutorials/add-a-pallet/configure-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/configure-a-pallet.md
@@ -131,9 +131,9 @@ configuration trait for the Nicks pallet. Add the following code to your runtime
 parameter_types! {
     // Choose a fee that incentivizes desireable behavior.
     pub const NickReservationFee: u128 = 100;
-    pub const MinNickLength: usize = 8;
+    pub const MinNickLength: u32 = 8;
     // Maximum bounds on storage are important to secure your chain.
-    pub const MaxNickLength: usize = 32;
+    pub const MaxNickLength: u32 = 32;
 }
 
 impl pallet_nicks::Config for Runtime {


### PR DESCRIPTION
Nicks pallet seems to use u32 now.

Fixes support issue: https://github.com/substrate-developer-hub/substrate-node-template/compare/v3.0.0+monthly-2021-05...tutorials/solutions/add-a-pallet-v3.0.0+monthly-2021-05