### PR TITLE
Fix #1117 and clarify about UI refresh.

### DIFF
--- a/docs/tutorials/forkless-upgrade/scheduled-upgrade.md
+++ b/docs/tutorials/forkless-upgrade/scheduled-upgrade.md
@@ -60,12 +60,14 @@ In the previous section, the Scheduler pallet was configured with the `Root` ori
 [`ScheduleOrigin`](https://substrate.dev/rustdocs/latest/pallet_scheduler/trait.Config.html#associatedtype.ScheduleOrigin),
 which means that the `sudo` function (_not_ `sudo_unchecked_weight`) can be used to invoke the
 `schedule` function. Use this link to open the Polkadot JS Apps UI's Sudo tab:
-https://polkadot.js.org/apps/#/sudo?rpc=ws://127.0.0.1:9944. Wait until all the other fields have
-been filled in before providing the `when` parameter. Leave the `maybe_periodic` parameter empty and
-the `priority` parameter at its default value of `0`. Select the System pallet's `set_code` function
-as the `call` parameter and provide the Wasm binary as before. Leave the "with weight override"
-option deactivated. Once all the other fields have been filled in, use a block number about 10
-blocks (1 minute) in the future to fill in the `when` parameter and quickly submit the transaction.
+https://polkadot.js.org/apps/#/sudo?rpc=ws://127.0.0.1:9944 (If this site is already open, you may
+need a refresh for the Extrinsics of the Scheduler pallet to show). Wait until all the other fields
+have been filled in before providing the `when` parameter. Leave the `maybe_periodic` parameter
+empty and the `priority` parameter at its default value of `0`. Select the System pallet's
+`set_code` function as the `call` parameter and provide the Wasm binary as before. Leave the
+"with weight override" option deactivated. Once all the other fields have been filled in, use a
+block number about 10 blocks (1 minute) in the future to fill in the `when` parameter and quickly
+submit the transaction.
 
 ![Scheduled Upgrade Panel](assets/tutorials/forkless-upgrade/scheduled-upgrade.png)
 
@@ -81,4 +83,5 @@ corner of Polkadot JS Apps UI should reflect that the runtime version is now `10
 
 You can then observe the specific changes that were made in the upgrade by using the
 [Polkadot JS Apps UI Chain State](https://polkadot.js.org/apps/#/chainstate/constants?rpc=ws://127.0.0.1:9944)
-app to query the `existentialDeposit` constant value from the Balances pallet.
+app to query the `existentialDeposit` constant value from the Balances pallet. (You may again need
+to refresh the page)

--- a/docs/tutorials/forkless-upgrade/scheduled-upgrade.md
+++ b/docs/tutorials/forkless-upgrade/scheduled-upgrade.md
@@ -59,13 +59,20 @@ cargo build --release -p node-template-runtime
 In the previous section, the Scheduler pallet was configured with the `Root` origin as its
 [`ScheduleOrigin`](https://substrate.dev/rustdocs/latest/pallet_scheduler/trait.Config.html#associatedtype.ScheduleOrigin),
 which means that the `sudo` function (_not_ `sudo_unchecked_weight`) can be used to invoke the
-`schedule` function. Use this link to open the Polkadot JS Apps UI's Sudo tab:
-https://polkadot.js.org/apps/#/sudo?rpc=ws://127.0.0.1:9944 (If this site is already open, you may
-need a refresh for the Extrinsics of the Scheduler pallet to show). Wait until all the other fields
-have been filled in before providing the `when` parameter. Leave the `maybe_periodic` parameter
-empty and the `priority` parameter at its default value of `0`. Select the System pallet's
-`set_code` function as the `call` parameter and provide the Wasm binary as before. Leave the
-"with weight override" option deactivated. Once all the other fields have been filled in, use a
+`schedule` function. To upgrade the runtime:
+
+- Use [this link](https://polkadot.js.org/apps/#/sudo?rpc=ws://127.0.0.1:9944) to open the Polkadot JS Apps UI's Sudo tab. Refresh your browser if you have it already running to make sure that the 
+Extrinsics for the Scheduler pallet show. 
+- Wait until all the other fields
+have been filled in before providing the `when` parameter. 
+- Leave the `maybe_periodic` parameter
+empty and the `priority` parameter at its default value of `0`. 
+- Select the System pallet's
+`set_code` function as the `call` parameter and provide the Wasm binary as before.
+- Leave the
+"with weight override" option deactivated. 
+
+Once all the other fields have been filled in, use a
 block number about 10 blocks (1 minute) in the future to fill in the `when` parameter and quickly
 submit the transaction.
 

--- a/docs/tutorials/forkless-upgrade/sudo-upgrade.md
+++ b/docs/tutorials/forkless-upgrade/sudo-upgrade.md
@@ -107,7 +107,11 @@ First, add the Scheduler pallet as a dependency in the template node's runtime C
 **`runtime/Cargo.toml`**
 
 ```toml
-pallet-scheduler = { default-features = false, version = '3.0.0' }
+[dependencies.pallet-scheduler]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-09+1'
+version = '4.0.0-dev'
 
 #--snip--
 
@@ -151,7 +155,7 @@ construct_runtime!(
     UncheckedExtrinsic = UncheckedExtrinsic
   {
     /*** snip ***/
-    Scheduler: pallet_scheduler::{Module, Call, Storage, Event<T>},
+    Scheduler: pallet_scheduler::{Pallet, Call, Storage, Event<T>},
   }
 );
 ```
@@ -205,6 +209,8 @@ cargo build --release -p node-template-runtime
 > Get stuck? Here is a
 > [solution](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/runtime-upgrade-v3)
 > to check against. See [the `diff` in the commit history for details](https://github.com/substrate-developer-hub/substrate-node-template/compare/1c5b984ccadf76cdbc0edd0e82594d57e412b257...tutorials/solutions/runtime-upgrade-v3).
+
+<!-- The solution might confuse more, as some parts of it are outdated and do not work against the current `4.0.0-dev` version -->
 
 Here the `--release` flag will result in a longer compile time, but also generate a smaller build
 artifact that is better suited for submitting to the blockchain network: storage minimization

--- a/docs/tutorials/forkless-upgrade/sudo-upgrade.md
+++ b/docs/tutorials/forkless-upgrade/sudo-upgrade.md
@@ -207,10 +207,8 @@ cargo build --release -p node-template-runtime
 ```
 
 > Get stuck? Here is a
-> [solution](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/runtime-upgrade-v3)
-> to check against. See [the `diff` in the commit history for details](https://github.com/substrate-developer-hub/substrate-node-template/compare/1c5b984ccadf76cdbc0edd0e82594d57e412b257...tutorials/solutions/runtime-upgrade-v3).
-
-<!-- The solution might confuse more, as some parts of it are outdated and do not work against the current `4.0.0-dev` version -->
+> [solution](https://github.com/substrate-developer-hub/substrate-node-template/tree/tutorials/solutions/runtime-upgrade)
+> to check against. See [the `diff` in the commit history for details](https://github.com/substrate-developer-hub/substrate-node-template/commit/ae3d9618b1b65c66ff7399fc91f7e9838d9c85ea).
 
 Here the `--release` flag will result in a longer compile time, but also generate a smaller build
 artifact that is better suited for submitting to the blockchain network: storage minimization


### PR DESCRIPTION
Addresses #1117. Also contains clarifies that the Apps/Explorer might need a refresh to before upgrades show/are usable, as I got quite confused about seeing version 102 of the blockchain, but still getting 500 pUnits as ExistentialDeposit, when I should have gotten 100. Refreshing fixed that.