### PR TITLE
Update tutorial's cargo dependencies tags

### DIFF
--- a/docs/tutorials/add-a-pallet/import-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/import-a-pallet.md
@@ -42,10 +42,12 @@ your runtime has. For example, it depends on the [Balances pallet](https://subst
 
 **`runtime/Cargo.toml`**
 
-```TOML
-[dependencies]
-#--snip--
-pallet-balances = { default-features = false, version = 'SEMVER VERSION', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-YYYY-MM' }
+```toml
+[dependencies.pallet-balances]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-YYYY-MM'
+version = 'SEMVER VERSION'
 ```
 
 This is telling Cargo to find the crate from git repository `paritytech/substrate` with commit
@@ -66,7 +68,7 @@ something like:
 
 **`runtime/Cargo.toml`**
 
-```TOML
+```toml
 [features]
 default = ['std']
 std = [
@@ -135,10 +137,13 @@ So based on the `balances` import shown above, the `nicks` import will look like
 
 **`runtime/Cargo.toml`**
 
-```TOML
-[dependencies]
-#--snip--
-pallet-nicks = { default-features = false, version = '4.0.0-dev', git = 'https://github.com/paritytech/substrate.git', tag = 'monthly-2021-09+1' }
+```toml
+# *** Add the following lines ***
+[dependencies.pallet-nicks]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-09+1'
+version = '4.0.0-dev'
 ```
 
 > Note you must use the correct [tag and version](#importing-a-pallet-crate) for the specific version of the node template you are using.
@@ -150,7 +155,7 @@ feature.
 
 **`runtime/Cargo.toml`**
 
-```TOML
+```toml
 [features]
 default = ["std"]
 std = [

--- a/docs/tutorials/add-contracts-pallet.md
+++ b/docs/tutorials/add-contracts-pallet.md
@@ -65,12 +65,12 @@ your runtime has. For example, it depends on the
 
 **`runtime/Cargo.toml`**
 
-```TOML
+```toml
 [dependencies.pallet-balances]
 default-features = false
-version = '4.0.0-dev'
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
+version = '4.0.0-dev'
 ```
 
 ### Crate Features
@@ -82,7 +82,7 @@ something like:
 
 **`runtime/Cargo.toml`**
 
-```TOML
+```toml
 [features]
 default = ['std']
 std = [
@@ -143,19 +143,18 @@ So based on the `balances` import shown above, the `contracts` import will look 
 
 **`runtime/Cargo.toml`**
 
-```TOML
-[dependencies]
-#--snip--
+```toml
+# *** Add the following lines ***
 [dependencies.pallet-contracts]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-primitives]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 ```
 
@@ -165,7 +164,7 @@ when the runtime is built with its own `std` feature. Add the following two line
 
 **`runtime/Cargo.toml`**
 
-```TOML
+```toml
 [features]
 default = ['std']
 std = [
@@ -347,22 +346,23 @@ We start by adding the required API dependencies in our `Cargo.toml`.
 
 **`runtime/Cargo.toml`**
 
-```TOML
+```toml
 [dependencies.pallet-contracts-rpc-runtime-api]
 default-features = false
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 ```
 
 **`runtime/Cargo.toml`**
 
-```TOML
+```toml
 [features]
 default = ['std']
 std = [
    #--snip--
    'pallet-contracts-rpc-runtime-api/std',
+   #--snip--
 ]
 ```
 
@@ -444,22 +444,17 @@ don't have to maintain a dedicated `std` feature.
 **`node/Cargo.toml`**
 
 ```toml
-[dependencies]
-jsonrpc-core = '15.1.0'
-structopt = '0.3.8'
-#--snip--
 # *** Add the following lines ***
 [dependencies.pallet-contracts]
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 
 [dependencies.pallet-contracts-rpc]
 git = 'https://github.com/paritytech/substrate.git'
-tag = 'monthly-2021-08'
+tag = 'monthly-2021-09+1'
 version = '4.0.0-dev'
 ```
-
 
 Substrate provides an RPC to interact with our node. However, it does not contain access to the
 Contracts pallet by default. To interact with this pallet, we have to extend the existing RPC and

--- a/docs/tutorials/build-a-dapp/pallet.md
+++ b/docs/tutorials/build-a-dapp/pallet.md
@@ -181,13 +181,13 @@ update our pallet's dependencies:
 **`pallet/template/Cargo.toml`**
 
 ```toml
-# add `sp-std` in the dependencies section of the toml file
-
-[dependencies]
-# -- snip -- 
-sp-std = { default-features = false, version = '3.0.0' }
-# -- snip --
-```  
+# *** Add the following lines ***
+[dependencies.sp-std]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-09+1'
+version = '4.0.0-dev'
+```
 
 ### 4. Pallet Errors
 

--- a/docs/tutorials/build-permission-network/add-node-authorization-pallet.md
+++ b/docs/tutorials/build-permission-network/add-node-authorization-pallet.md
@@ -72,12 +72,17 @@ First we must add the pallet to our runtime dependencies:
 
 **`runtime/Cargo.toml`**
 
-```TOML
-[dependencies]
-#--snip--
-pallet-node-authorization = { default-features = false, version = '3.0.0' }
+```toml
+[dependencies.pallet-node-authorization]
+default-features = false
+git = 'https://github.com/paritytech/substrate.git'
+tag = 'monthly-2021-09+1'
+version = '4.0.0-dev'
+```
 
-#--snip--
+**`runtime/Cargo.toml`**
+
+```toml
 [features]
 default = ['std']
 std = [
@@ -86,6 +91,7 @@ std = [
     #--snip--
 ]
 ```
+
 We need to simulate the governance in our simple blockchain, so we just let a `sudo` admin rule, 
 configuring the pallet's interface to `EnsureRoot`. In a production environment we sould want to have 
 difference, governance based checking implimented here. More details of this `Config` can be found in
@@ -148,9 +154,9 @@ construct_runtime!(
 `PeerId` is encoded in bs58 format, so we need a new library
 [bs58](https://docs.rs/bs58/0.3.1/bs58/) in **node/cargo.toml** to decode it to get its bytes.
 
-**`node/cargo.toml`**
+**`node/Cargo.toml`**
 
-```TOML
+```toml
 [dependencies]
 #--snip--
 bs58 = "0.4.0"


### PR DESCRIPTION
For readers that are going through the tutorials after [#232](https://github.com/substrate-developer-hub/substrate-node-template/pull/234) landed, they are likely to have issues with conflicting/old cargo dependencies such as #1122 , #1117, and #1094, if they inadvertently copy the Cargo.toml snips that were not updated.
This PR updates the tags for the tutorials, leaving only **forkless-upgrade** tutorial out as there is an open PR updating it already: #1118.
ty.