### PR TITLE
Fixed broken link to the trait docs

### DIFF
--- a/docs/tutorials/add-a-pallet/configure-a-pallet.md
+++ b/docs/tutorials/add-a-pallet/configure-a-pallet.md
@@ -30,7 +30,7 @@ trait for the Nicks pallet.
 
 To figure out what you need to implement for the Nicks pallet specifically, you can take a look at
 the
-[`pallet_nicks::Config` documentation](https://substrate.dev/rustdocs/latest/pallet_nicks/trait.Config.html)
+[`pallet_nicks::Config` documentation](https://substrate.dev/rustdocs/latest/pallet_nicks/pallet/trait.Config.html)
 or the definition of the trait itself in
 [the source code](https://github.com/paritytech/substrate/blob/master/frame/nicks/src/lib.rs) of the
 Nicks pallet. We have annotated the source code for `nicks` pallet _from the substrate source_ below with


### PR DESCRIPTION
- [+ ] Are the audience and objective of the document clear? E.g. a document for developers that should teach them about transaction fees.
- [ +] Is the writing:
  - [+ ] Clear: No jargon.
  - [ +] Precise: No ambiguous meanings.
  - [ +] Concise: Free of superfluous detail.
- [ +] Does it follow our style guide?
- [ +] If this is a new page, does the PR include the appropriate infrastructure, e.g. adding the page to a sidebar?
- [ +] Build the page ($ cd website && yarn start). Does it render properly? E.g. no funny lists or formatting.
- [ +] Do links go to rustdocs or devhub articles rather than code?
- [ +] If this PR addresses an issue in the queue, have you referenced it in the description?
