### PR TITLE
rm link checks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,12 +112,10 @@ workflows:
           filters: *only-source
           requires:
             - check-build
-            - check-links
       - deploy-to-staging:
           filters: *only-staging-source
           requires:
             - check-build
-            - check-links
 
   nightly_deploy:
     triggers:


### PR DESCRIPTION
to deploy, then we move to archive
if needed, I (or anyone with write access and ssh&gpg  keys configured) can manually publish with:
```
yarn build
USE_SSH=true GIT_USER=git yarn run publish-gh-pages
```
